### PR TITLE
Build a docker image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,50 @@
+name: Build Docker image
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  JAVA_VERSION: 17
+
+jobs:
+  docker:
+    name: Push to GitHub Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up JDK
+        uses: "actions/setup-java@v1"
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Checkout
+        uses: "actions/checkout@v2"
+
+      - name: Docker meta
+        id: docker_meta
+        uses: "crazy-max/ghaction-docker-meta@v1"
+        with:
+          images: "ghcr.io/${{ github.repository }}"
+          tag-sha: true
+          tag-custom: latest
+
+      - name: "Unfuck fucked up build script"
+        run: |
+          rm build
+          sed -i 's/buildDir = File("_build")/buildDir = File("build")/g' build.gradle.kts
+
+      - name: "Login to ghcr.io"
+        uses: "docker/login-action@v1"
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish Docker Image
+        env:
+          IMAGE_TAGS: ${{ steps.docker_meta.outputs.tags }}
+        run: ./gradlew jib

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,18 @@ val integrationTest = task<Test>("integrationTest") {
 jib {
 	from.image = "eclipse-temurin:17"
 	to {
-		image = "firmwehr/gentle:latest"
+		image = "ghcr.io/firmwehr/gentle:latest"
+
+		// here be dragons
+		System.getenv("IMAGE_TAGS")?.apply {
+			tags = split("[,\\n]".toRegex())
+				.map { it.split(":")[1] }
+				.toCollection(mutableSetOf())
+		}
+
+		container {
+			environment = mapOf("GENTLE_ENABLE_LOG" to "true")
+		}
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	application
+	id("com.google.cloud.tools.jib") version "3.1.4"
 }
 
 group = "com.github.firmwehr"
@@ -49,6 +50,13 @@ val integrationTest = task<Test>("integrationTest") {
 	testClassesDirs = sourceSets["integrationTest"].output.classesDirs
 	classpath = sourceSets["integrationTest"].runtimeClasspath
 	shouldRunAfter("test")
+}
+
+jib {
+	from.image = "eclipse-temurin:17"
+	to {
+		image = "firmwehr/gentle:latest"
+	}
 }
 
 dependencies {


### PR DESCRIPTION
A docker image might be helpful for our windows friends to try out the compiler in a production environment :)

You can build it using `./gradlew jibDockerBuild`.