### PR TITLE
Allow Optional<T> in class fields

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -27,3 +27,4 @@ include:
   - name: UseOfClone
 exclude:
   - name: JavaAnnotator # Counter - Hours wasted: 4
+  - name: OptionalUsedAsFieldOrParameterType


### PR DESCRIPTION
We decided on using `Optional<T>` rather than `null` in class fields, if necessary.