### PR TITLE
Fix wrong exit code for lextest command

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -80,6 +80,7 @@ public class GentleCompiler {
 			System.out.flush();
 		} catch (IOException e) {
 			LOGGER.error("Could not echo file '{}': {}", path, e.getMessage());
+			System.exit(1);
 		}
 	}
 


### PR DESCRIPTION
Make lextest return proper error code.

Closes #36 