### PR TITLE
Add macOS DS_Store files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # application stuff
 *.log
+
+# OS Stuff
+*.DS_Store


### PR DESCRIPTION
macOS leaves a .DS_Store file in every. single. folder.