### PR TITLE
Fix parsing of NewArrayExpressions next to an ArrayAccess

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -501,9 +501,17 @@ public class Parser {
 			tokens.expectOperator(Operator.RIGHT_BRACKET);
 
 			int arrayLevel = 1;
-			while (tokens.expectingOperator(Operator.LEFT_BRACKET).peek().isOperator(Operator.LEFT_BRACKET)) {
+			// This loop checks for the closing bracket in addition to the opening bracket because if there is
+			// anything between the brackets, it is considered an array access and not part of the NewArrayExpression.
+			//
+			// For example, the expression `new int[1][2]` is parsed as a NewArrayExpression `new int[1]` followed by
+			// a PostfixExpression with ArrayAccess `[2]` as its single PostfixOp. This means that `new int[1][2]` is
+			// equivalent to `(new int[1])[2]`.
+			while (tokens.expectingOperator(Operator.LEFT_BRACKET).peek().isOperator(Operator.LEFT_BRACKET) &&
+				tokens.peek(1).isOperator(Operator.RIGHT_BRACKET)) {
+
 				tokens.take();
-				tokens.expectOperator(Operator.RIGHT_BRACKET);
+				tokens.take();
 				arrayLevel++;
 			}
 

--- a/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
@@ -29,7 +29,11 @@ class ParserTest {
 	}
 
 	// This wrapper allows us to give the parameterized test cases nice labels
-	private record ParserTestCase(String label, String source, Program expectedProgram) {
+	private record ParserTestCase(
+		String label,
+		String source,
+		Program expectedProgram
+	) {
 		@Override
 		public String toString() {
 			return label();
@@ -527,7 +531,34 @@ class ParserTest {
 								.thenEmpty().thenEmpty().thenEmpty().thenEmpty()
 								.thenEmpty().thenEmpty().thenEmpty().thenEmpty()
 								.thenEmpty().thenEmpty().thenEmpty().thenEmpty().thenEmpty().thenEmpty())))
-				))
+				)),
+			Arguments.of(new ParserTestCase(
+				"array access on a NewArrayExpression",
+				"""
+				class Foo {
+					public void bar() {
+						new int[1][2];
+						new Foo[3][][4];
+						new void[5][][][];
+					}
+				}
+				""",
+				new Program()
+					.withDecl(new ClassDeclaration("Foo")
+						.withMethod(new Method("bar")
+							.withBody(Statement.newBlock()
+								.thenExpr(Expression.newNewArray(
+									Type.newInt().atLevel(1),
+									Expression.newInt(1)
+								).withArrayAccess(Expression.newInt(2)))
+								.thenExpr(Expression.newNewArray(
+									Type.newIdent("Foo").atLevel(2),
+									Expression.newInt(3)
+								).withArrayAccess(Expression.newInt(4)))
+								.thenExpr(Expression.newNewArray(
+									Type.newVoid().atLevel(4),
+									Expression.newInt(5)
+								)))))))
 		);
 		// @formatter:on
 	}


### PR DESCRIPTION
An expression like `new int[1][2]` should be parsed as `(new int[1])[2]` instead of resulting in an error.