### PR TITLE
Reject non-ASCII source strings

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -10,6 +10,7 @@ import com.github.firmwehr.gentle.parser.ParseException;
 import com.github.firmwehr.gentle.parser.Parser;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceException;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
@@ -100,10 +101,13 @@ public class GentleCompiler {
 				}
 			}
 		} catch (IOException e) {
-			LOGGER.error("Could not read for lextest file '{}': {}", path, e.getMessage());
+			LOGGER.error("Could not read file '{}': {}", path, e.getMessage());
+			System.exit(1);
+		} catch (SourceException e) {
+			LOGGER.error("Error reading file '{}': {}", path, e.getMessage());
 			System.exit(1);
 		} catch (LexerException e) {
-			LOGGER.error("lextest failed", e);
+			LOGGER.error("Lexing failed", e);
 			System.exit(1);
 		}
 	}
@@ -116,6 +120,9 @@ public class GentleCompiler {
 			LOGGER.info("Parse result:\n{}", PrettyPrinter.format(parser.parse()));
 		} catch (IOException e) {
 			LOGGER.error("Could not read file '{}': {}", path, e.getMessage());
+			System.exit(1);
+		} catch (SourceException e) {
+			LOGGER.error("Error reading file '{}': {}", path, e.getMessage());
 			System.exit(1);
 		} catch (LexerException e) {
 			LOGGER.error("Lexing failed", e);

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -1,7 +1,5 @@
 package com.github.firmwehr.gentle.source;
 
-import com.google.common.base.Preconditions;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -11,9 +9,10 @@ public class Source {
 	private final String content;
 	private final List<String> lines;
 
-	public Source(String content) {
-		Preconditions.checkArgument(content.codePoints().allMatch(c -> c <= 127),
-			"content must consist exclusively of ASCII characters");
+	public Source(String content) throws SourceException {
+		if (!content.codePoints().allMatch(c -> c <= 127)) {
+			throw new SourceException("input contains non-ASCII characters");
+		}
 
 		this.content = content;
 		this.lines = content.lines().collect(Collectors.toList());

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -1,5 +1,7 @@
 package com.github.firmwehr.gentle.source;
 
+import com.google.common.base.Preconditions;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -10,6 +12,9 @@ public class Source {
 	private final List<String> lines;
 
 	public Source(String content) {
+		Preconditions.checkArgument(content.codePoints().allMatch(c -> c <= 127),
+			"content must consist exclusively of ASCII characters");
+
 		this.content = content;
 		this.lines = content.lines().collect(Collectors.toList());
 	}

--- a/src/main/java/com/github/firmwehr/gentle/source/SourceException.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/SourceException.java
@@ -1,0 +1,7 @@
+package com.github.firmwehr.gentle.source;
+
+public class SourceException extends Exception {
+	public SourceException(String message) {
+		super(message);
+	}
+}

--- a/src/test/java/com/github/firmwehr/gentle/lexer/LexReaderTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/lexer/LexReaderTest.java
@@ -5,7 +5,6 @@ import com.github.firmwehr.gentle.source.SourcePosition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 public class LexReaderTest {
@@ -43,44 +42,5 @@ public class LexReaderTest {
 
 		assertThat(line).isEqualTo(diff1);
 		assertThat(diff1).isEqualTo(diff2);
-	}
-
-	@Test
-	void testUnicodeInReadLine() throws LexerException {
-		String comment = "//This is a \uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9 comment\nX";
-		var reader = new LexReader(new Source(comment));
-		var reader2 = reader.fork();
-
-		var line = reader.readLine();
-		var diff = reader2.diff(reader);
-		assertThat(line).isEqualTo("//This is a \uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9 comment\n");
-		assertThat(line).isEqualTo(diff);
-	}
-
-	@Test
-	void testUnicodeInPeekN() throws LexerException {
-		String input = "\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9";
-		var reader = new LexReader(new Source(input));
-
-		var line = reader.peek(2);
-		assertThat(line).isEqualTo("\uD83D\uDCA9\uD83D\uDCA9");
-	}
-
-	@Test
-	void testUnicodeInPeekNExactLength() throws LexerException {
-		String input = "\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9";
-		var reader = new LexReader(new Source(input));
-
-		var line = reader.peek(4);
-		assertThat(line).isEqualTo(input);
-	}
-
-	@Test
-	void testUnicodeInPeekNTooMuch() {
-		String input = "\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9\uD83D\uDCA9";
-		var reader = new LexReader(new Source(input));
-
-		assertThatThrownBy(() -> reader.peek(5)).isInstanceOf(LexerException.class)
-			.hasMessageContaining("1"); // peeking 1 codepoint too much should be described
 	}
 }

--- a/src/test/java/com/github/firmwehr/gentle/lexer/LexerTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/lexer/LexerTest.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.lexer;
 import com.github.firmwehr.gentle.lexer.tokens.TokenIdentifier;
 import com.github.firmwehr.gentle.lexer.tokens.TokenWhitespace;
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceException;
 import com.github.firmwehr.gentle.source.SourcePosition;
 import com.github.firmwehr.gentle.source.SourceSpan;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LexerTest {
 
 	@Test
-	void testRecognizeWindowsLineBreaks() throws LexerException {
+	void testRecognizeWindowsLineBreaks() throws SourceException, LexerException {
 		String tokens = "Hello\r\nWorld";
 		Lexer lexer = new Lexer(new Source(tokens));
 		assertThat(lexer.nextToken()).isEqualTo(
@@ -24,7 +25,7 @@ class LexerTest {
 	}
 
 	@Test
-	void testRecognizeMultipleWindowsLineBreaks() throws LexerException {
+	void testRecognizeMultipleWindowsLineBreaks() throws SourceException, LexerException {
 		String tokens = "Hello\r\n\r\nWorld";
 		Lexer lexer = new Lexer(new Source(tokens));
 		assertThat(lexer.nextToken()).isEqualTo(
@@ -36,7 +37,7 @@ class LexerTest {
 	}
 
 	@Test
-	void testRecognizeLinuxLineBreaks() throws LexerException {
+	void testRecognizeLinuxLineBreaks() throws SourceException, LexerException {
 		String tokens = "Hello\nWorld";
 		Lexer lexer = new Lexer(new Source(tokens));
 		assertThat(lexer.nextToken()).isEqualTo(
@@ -48,7 +49,7 @@ class LexerTest {
 	}
 
 	@Test
-	void testRecognizeMultipleLinuxLineBreaks() throws LexerException {
+	void testRecognizeMultipleLinuxLineBreaks() throws SourceException, LexerException {
 		String tokens = "Hello\n\nWorld";
 		Lexer lexer = new Lexer(new Source(tokens));
 		assertThat(lexer.nextToken()).isEqualTo(
@@ -60,7 +61,7 @@ class LexerTest {
 	}
 
 	@Test
-	void testRecognizeMixedLineBreaks() throws LexerException {
+	void testRecognizeMixedLineBreaks() throws SourceException, LexerException {
 		String tokens = "Hello\n\r\n\rWorld";
 		Lexer lexer = new Lexer(new Source(tokens));
 		assertThat(lexer.nextToken()).isEqualTo(

--- a/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
@@ -14,6 +14,7 @@ import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.parser.ast.statement.Statement;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,13 +24,17 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ParserTest {
-	private static Parser fromText(String text) throws LexerException {
+	private static Parser fromText(String text) throws SourceException, LexerException {
 		Source source = new Source(text);
 		return Parser.fromLexer(source, new Lexer(source, Lexer.tokenFilter(TokenType.WHITESPACE, TokenType.COMMENT)));
 	}
 
 	// This wrapper allows us to give the parameterized test cases nice labels
-	private record ParserTestCase(String label, String source, Program expectedProgram) {
+	private record ParserTestCase(
+		String label,
+		String source,
+		Program expectedProgram
+	) {
 		@Override
 		public String toString() {
 			return label();
@@ -39,7 +44,8 @@ class ParserTest {
 	@ParameterizedTest
 	@MethodSource("provideSyntacticallyCorrectPrograms")
 	public void parse_shouldConstructAstForSyntacticallyCorrectPrograms(ParserTestCase testCase)
-		throws LexerException, ParseException {
+		throws SourceException, LexerException, ParseException {
+
 		Parser parser = fromText(testCase.source());
 		Program actualProgram = parser.parse();
 


### PR DESCRIPTION
We should probably have better error handling, but crashing is better than doing nothing and just assuming the input is ASCII.