### PR TITLE
Allow special files like /dev/stdin to be used

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
@@ -33,9 +33,6 @@ public interface CommandArguments {
 			if (!Files.isReadable(path)) {
 				throw new IllegalArgumentException("The file '%s' is not readable".formatted(path));
 			}
-			if (!Files.isRegularFile(path)) {
-				throw new IllegalArgumentException("The file '%s' is not a regular file".formatted(path));
-			}
 
 			return path;
 		}


### PR DESCRIPTION
These changes remove an additional check in the input file handling that prevents `/dev/stdin` and similar files from working.

Closes #61 