### PR TITLE
Reduce format overhead for logger

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
+++ b/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
@@ -91,7 +91,9 @@ public class Lexer {
 			throw new Error("parsed token from empty string, this is an error in the code");
 		}
 
-		LOGGER.trace("emitting token {} from string slice @ {}: '{}'", token, token.sourceSpan().format(), diff);
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("emitting token {} from string slice @ {}: '{}'", token, token.sourceSpan().format(), diff);
+		}
 		reader = childReader;
 		return token;
 	}

--- a/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
@@ -18,6 +18,6 @@ public record SourceSpan(
 	}
 
 	public String format() {
-		return "%s..%s".formatted(start.format(), end.format());
+		return start.format() + ".." + end.format();
 	}
 }


### PR DESCRIPTION
While the logger itself does not introduce much overhead for logging calls, the formatting of elements before passing them to the logger is inefficient. By checking if the log level is enabled before formatting, this overhead can be avoided.