### PR TITLE
Only read ASCII files by default

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -11,11 +11,11 @@ import com.github.firmwehr.gentle.parser.Parser;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
 import com.github.firmwehr.gentle.parser.tokens.Token;
 import com.github.firmwehr.gentle.source.Source;
-import com.github.firmwehr.gentle.source.SourceException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,11 +77,11 @@ public class GentleCompiler {
 			}
 
 			UserOutput.outputData(outputStream);
+		} catch (MalformedInputException e) {
+			UserOutput.userError("File contains invalid characters '%s': %s", path, e.getMessage());
+			System.exit(1);
 		} catch (IOException e) {
 			UserOutput.userError("Could not read file '%s': %s", path, e.getMessage());
-			System.exit(1);
-		} catch (SourceException e) {
-			UserOutput.userError("Error reading file '%s': %s", path, e.getMessage());
 			System.exit(1);
 		} catch (LexerException e) {
 			UserOutput.userError(e);
@@ -95,11 +95,11 @@ public class GentleCompiler {
 			Lexer lexer = new Lexer(source, true);
 			Parser parser = Parser.fromLexer(source, lexer);
 			parser.parse(); // result ignored for now
+		} catch (MalformedInputException e) {
+			UserOutput.userError("File contains invalid characters '%s': %s", path, e.getMessage());
+			System.exit(1);
 		} catch (IOException e) {
 			UserOutput.userError("Could not read file '%s': %s", path, e.getMessage());
-			System.exit(1);
-		} catch (SourceException e) {
-			UserOutput.userError("Error reading file '%s': %s", path, e.getMessage());
 			System.exit(1);
 		} catch (LexerException | ParseException e) {
 			UserOutput.userError(e);
@@ -113,11 +113,11 @@ public class GentleCompiler {
 			Lexer lexer = new Lexer(source, true);
 			Parser parser = Parser.fromLexer(source, lexer);
 			LOGGER.info("Parse result:\n%s", PrettyPrinter.format(parser.parse()));
+		} catch (MalformedInputException e) {
+			UserOutput.userError("File contains invalid characters '%s': %s", path, e.getMessage());
+			System.exit(1);
 		} catch (IOException e) {
 			UserOutput.userError("Could not read file '%s': %s", path, e.getMessage());
-			System.exit(1);
-		} catch (SourceException e) {
-			UserOutput.userError("Error reading file '%s': %s", path, e.getMessage());
 			System.exit(1);
 		} catch (LexerException | ParseException e) {
 			UserOutput.userError(e);

--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -72,7 +72,7 @@ public class GentleCompiler {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
 			for (Token token : lexer.lex()) {
-				outputStream.writeBytes(token.format().getBytes(StandardCharsets.UTF_8));
+				outputStream.writeBytes(token.format().getBytes(FILE_CHARSET));
 				outputStream.write('\n');
 			}
 

--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -15,6 +15,7 @@ import com.github.firmwehr.gentle.source.SourceException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,6 +23,7 @@ import java.nio.file.Path;
 public class GentleCompiler {
 
 	private static final Logger LOGGER = new Logger(GentleCompiler.class);
+	private static final Charset FILE_CHARSET = StandardCharsets.US_ASCII;
 
 	public static void main(String[] args) {
 		LOGGER.info("Hello World, please be gentle UwU");
@@ -65,7 +67,7 @@ public class GentleCompiler {
 
 	private static void lexTestCommand(Path path) {
 		try {
-			var source = new Source(Files.readString(path, StandardCharsets.UTF_8));
+			var source = new Source(Files.readString(path, FILE_CHARSET));
 			var lexer = new Lexer(source, true);
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -89,7 +91,7 @@ public class GentleCompiler {
 
 	private static void parseTestCommand(Path path) {
 		try {
-			Source source = new Source(Files.readString(path, StandardCharsets.UTF_8));
+			Source source = new Source(Files.readString(path, FILE_CHARSET));
 			Lexer lexer = new Lexer(source, true);
 			Parser parser = Parser.fromLexer(source, lexer);
 			parser.parse(); // result ignored for now
@@ -107,7 +109,7 @@ public class GentleCompiler {
 
 	private static void runCommand(Path path) {
 		try {
-			Source source = new Source(Files.readString(path, StandardCharsets.UTF_8));
+			Source source = new Source(Files.readString(path, FILE_CHARSET));
 			Lexer lexer = new Lexer(source, true);
 			Parser parser = Parser.fromLexer(source, lexer);
 			LOGGER.info("Parse result:\n%s", PrettyPrinter.format(parser.parse()));

--- a/src/main/java/com/github/firmwehr/gentle/lexer/StringReader.java
+++ b/src/main/java/com/github/firmwehr/gentle/lexer/StringReader.java
@@ -19,7 +19,7 @@ public class StringReader {
 	 * @param source the underlying source
 	 */
 	public StringReader(Source source) {
-		this.underlying = source.getContent();
+		this.underlying = source.content();
 		this.source = source;
 		this.position = 0;
 	}

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -9,10 +9,6 @@ public class Source {
 	private final String content;
 
 	public Source(String content) throws SourceException {
-		if (!content.codePoints().allMatch(c -> c <= 127)) {
-			throw new SourceException("input contains non-ASCII characters");
-		}
-
 		this.content = content;
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -2,19 +2,7 @@ package com.github.firmwehr.gentle.source;
 
 import com.github.firmwehr.gentle.util.Pair;
 
-import java.util.Objects;
-
-public class Source {
-
-	private final String content;
-
-	public Source(String content) throws SourceException {
-		this.content = content;
-	}
-
-	public String getContent() {
-		return content;
-	}
+public record Source(String content) {
 
 	/**
 	 * Find the beginning of the line a certain character is in. If the character is part of a linebreak, it belongs to
@@ -134,22 +122,5 @@ public class Source {
 		builder.append("^ ").append(description);
 
 		return builder.toString();
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		Source source = (Source) o;
-		return Objects.equals(content, source.content);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(content);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/source/SourceException.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/SourceException.java
@@ -1,7 +1,0 @@
-package com.github.firmwehr.gentle.source;
-
-public class SourceException extends Exception {
-	public SourceException(String message) {
-		super(message);
-	}
-}

--- a/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/parser/ParserTest.java
@@ -13,7 +13,6 @@ import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.parser.ast.statement.Statement;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
 import com.github.firmwehr.gentle.source.Source;
-import com.github.firmwehr.gentle.source.SourceException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,7 +22,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ParserTest {
-	private static Parser fromText(String text) throws SourceException, LexerException {
+	private static Parser fromText(String text) throws LexerException {
 		Source source = new Source(text);
 		return Parser.fromLexer(source, new Lexer(source, true));
 	}
@@ -43,7 +42,7 @@ class ParserTest {
 	@ParameterizedTest
 	@MethodSource("provideSyntacticallyCorrectPrograms")
 	public void parse_shouldConstructAstForSyntacticallyCorrectPrograms(ParserTestCase testCase)
-		throws SourceException, LexerException, ParseException {
+		throws LexerException, ParseException {
 
 		Parser parser = fromText(testCase.source());
 		Program actualProgram = parser.parse();

--- a/src/test/java/com/github/firmwehr/gentle/source/SourceTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/source/SourceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SourceTest {
 
 	@Test
-	void multipleLinuxLineEndings() throws SourceException {
+	void multipleLinuxLineEndings() {
 		Source source = new Source("Hello\n\nWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
@@ -24,7 +24,7 @@ class SourceTest {
 	}
 
 	@Test
-	void multipleWindowsLineEndings() throws SourceException {
+	void multipleWindowsLineEndings() {
 		Source source = new Source("Hello\r\n\r\nWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
@@ -45,7 +45,7 @@ class SourceTest {
 	}
 
 	@Test
-	void multipleMacLineEndings() throws SourceException {
+	void multipleMacLineEndings() {
 		Source source = new Source("Hello\r\rWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
@@ -62,7 +62,7 @@ class SourceTest {
 	}
 
 	@Test
-	void linuxLineEndings() throws SourceException {
+	void linuxLineEndings() {
 		Source source = new Source("Hello\nWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
@@ -76,7 +76,7 @@ class SourceTest {
 	}
 
 	@Test
-	void windowsLineEndings() throws SourceException {
+	void windowsLineEndings() {
 		Source source = new Source("Hello\r\nWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
@@ -92,7 +92,7 @@ class SourceTest {
 	}
 
 	@Test
-	void macLineEndings() throws SourceException {
+	void macLineEndings() {
 		Source source = new Source("Hello\rWorld");
 
 		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));


### PR DESCRIPTION
by enforcing US_ASCII as charset, we can guarantee that the files we read are always in a valid format. That way, we don't need to check that manually again.