### PR TITLE
Implement own StringTable

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
+++ b/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
@@ -12,6 +12,8 @@ import com.github.firmwehr.gentle.parser.tokens.Token;
 import com.github.firmwehr.gentle.parser.tokens.WhitespaceToken;
 import com.github.firmwehr.gentle.source.Source;
 import com.github.firmwehr.gentle.source.SourceSpan;
+import com.github.firmwehr.gentle.util.string.SimpleStringTable;
+import com.github.firmwehr.gentle.util.string.StringTable;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -20,6 +22,7 @@ import java.util.Optional;
 
 public class Lexer {
 
+	private final StringTable stringTable = new SimpleStringTable();
 	private final StringReader reader;
 	private final boolean onlyRelevantTokens;
 
@@ -80,8 +83,8 @@ public class Lexer {
 		String read = reader.readChar() + reader.readWhile(this::isIdentifierPart);
 
 		Optional<Token> keywordToken = getKeywordToken(start, reader.getPosition(), read);
-		return keywordToken.orElseGet(() -> new IdentToken(new SourceSpan(start, reader.getPosition()),
-			read.intern()));
+		return keywordToken.orElseGet(
+			() -> new IdentToken(new SourceSpan(start, reader.getPosition()), stringTable.deduplicate(read)));
 	}
 
 	private Token readOperator(String errorMessage) throws LexerException {

--- a/src/main/java/com/github/firmwehr/gentle/util/string/SimpleStringTable.java
+++ b/src/main/java/com/github/firmwehr/gentle/util/string/SimpleStringTable.java
@@ -1,0 +1,14 @@
+package com.github.firmwehr.gentle.util.string;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class SimpleStringTable implements StringTable {
+	private final Map<String, String> table = new HashMap<>();
+
+	@Override
+	public String deduplicate(String str) {
+		return table.computeIfAbsent(str, Function.identity());
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/util/string/StringTable.java
+++ b/src/main/java/com/github/firmwehr/gentle/util/string/StringTable.java
@@ -1,0 +1,6 @@
+package com.github.firmwehr.gentle.util.string;
+
+public interface StringTable {
+
+	String deduplicate(String str);
+}


### PR DESCRIPTION
This allows us to have more control over String deduplication. The current implementation is pretty much straightforward and seems to be beneficial for performance.