### PR TITLE
Handle lists and optionals when checking record equality in tests

### DIFF
--- a/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
+++ b/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
@@ -16,7 +16,8 @@ public final class Equality {
 	) {
 		Preconditions.checkArgument(obj.getClass().isRecord(), "must be a record type comparison");
 		return new Condition<>(new EqualityChecker<>(obj, attributeTypes, deepScanRecords, deepScanCollections),
-			"a record ignoring following attributes " + (deepScanRecords ? "deeply " : "") + attributeTypes);
+			"a record ignoring following attributes " + (deepScanRecords ? "deeply " : "") + attributeTypes + "\n  " +
+				obj);
 	}
 
 	public static <T> Condition<? super T> equalExcept(

--- a/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
+++ b/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
@@ -11,17 +11,21 @@ public final class Equality {
 
 	}
 
-	public static <T> Condition<? super T> equalExcept(T obj, Set<Class<?>> attributeTypes, boolean deepScanRecords) {
+	public static <T> Condition<? super T> equalExcept(
+		T obj, Set<Class<?>> attributeTypes, boolean deepScanRecords, boolean deepScanCollections
+	) {
 		Preconditions.checkArgument(obj.getClass().isRecord(), "must be a record type comparison");
-		return new Condition<>(new EqualityChecker<>(obj, attributeTypes, deepScanRecords),
+		return new Condition<>(new EqualityChecker<>(obj, attributeTypes, deepScanRecords, deepScanCollections),
 			"a record ignoring following attributes " + (deepScanRecords ? "deeply " : "") + attributeTypes);
 	}
 
-	public static <T> Condition<? super T> equalExcept(T obj, Class<?> attributeType, boolean deepScanRecords) {
-		return equalExcept(obj, Set.of(attributeType), deepScanRecords);
+	public static <T> Condition<? super T> equalExcept(
+		T obj, Class<?> attributeType, boolean deepScanRecords, boolean deepScanCollections
+	) {
+		return equalExcept(obj, Set.of(attributeType), deepScanRecords, deepScanCollections);
 	}
 
 	public static <T> Condition<? super T> equalExceptSourcePosition(T obj) {
-		return equalExcept(obj, SourcePosition.class, true);
+		return equalExcept(obj, SourcePosition.class, true, true);
 	}
 }

--- a/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
+++ b/src/test/java/com/github/firmwehr/gentle/testutil/Equality.java
@@ -1,6 +1,6 @@
 package com.github.firmwehr.gentle.testutil;
 
-import com.github.firmwehr.gentle.source.SourcePosition;
+import com.github.firmwehr.gentle.source.SourceSpan;
 import com.google.common.base.Preconditions;
 import org.assertj.core.api.Condition;
 
@@ -26,6 +26,6 @@ public final class Equality {
 	}
 
 	public static <T> Condition<? super T> equalExceptSourcePosition(T obj) {
-		return equalExcept(obj, SourcePosition.class, true, true);
+		return equalExcept(obj, SourceSpan.class, true, true);
 	}
 }

--- a/src/test/java/com/github/firmwehr/gentle/testutil/EqualityChecker.java
+++ b/src/test/java/com/github/firmwehr/gentle/testutil/EqualityChecker.java
@@ -5,7 +5,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,16 +15,20 @@ import java.util.function.Predicate;
 
 @SuppressWarnings("ClassCanBeRecord")
 public class EqualityChecker<T> implements Predicate<T> {
-	private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
+	private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 	private static final Map<Class<?>, List<MethodHandle>> ACCESSOR_CACHE = new HashMap<>();
 	private final T expected;
 	private final Set<Class<?>> exceptTypes;
-	private final boolean deep;
+	private final boolean deepScanRecords;
+	private final boolean deepScanCollections;
 
-	public EqualityChecker(T expected, Set<Class<?>> exceptTypes, boolean deep) {
+	public EqualityChecker(
+		T expected, Set<Class<?>> exceptTypes, boolean deepScanRecords, boolean deepScanCollections
+	) {
 		this.expected = expected;
 		this.exceptTypes = exceptTypes;
-		this.deep = deep;
+		this.deepScanRecords = deepScanRecords;
+		this.deepScanCollections = deepScanCollections;
 	}
 
 	@Override
@@ -36,6 +42,9 @@ public class EqualityChecker<T> implements Predicate<T> {
 		}
 		if (actual == null) {
 			return false;
+		}
+		if (!this.expected.getClass().isRecord() || !actual.getClass().isRecord()) {
+			return this.expected.equals(actual);
 		}
 		var handles = ACCESSOR_CACHE.computeIfAbsent(this.expected.getClass(), EqualityChecker::createAccessors);
 		for (MethodHandle handle : handles) {
@@ -62,13 +71,43 @@ public class EqualityChecker<T> implements Predicate<T> {
 			// if both are null, we consider them equal, if only one is null, we consider them not equal
 			return expectedAttribute == actualAttribute;
 		}
+		if (this.deepScanCollections && expectedAttribute instanceof Collection a &&
+			actualAttribute instanceof Collection b) {
+			return collectionsEqual(a, b);
+		}
 		// if we don't need to deeply scan records, we can just use normal equals here
-		if (!this.deep ||
+		if (!this.deepScanRecords ||
 			!(expectedAttribute.getClass().isRecord() && expectedAttribute.getClass() == actualAttribute.getClass())) {
 			return expectedAttribute.equals(actualAttribute);
 		}
 		// otherwise, we just run a check again on the attribute
-		return new EqualityChecker<>(expectedAttribute, this.exceptTypes, true).isEqual(actualAttribute);
+		return new EqualityChecker<>(expectedAttribute, this.exceptTypes, true, this.deepScanCollections).isEqual(
+			actualAttribute);
+	}
+
+	private boolean collectionsEqual(Collection<?> a, Collection<?> b) {
+		if (a == b) {
+			return true;
+		}
+		if (a.size() != b.size()) {
+			return false;
+		}
+		//noinspection SwitchStatementWithTooFewBranches
+		return switch (a) {
+			case List<?> list && b instanceof List<?> bList -> listsEqual(list, bList);
+			default -> a.equals(b);
+		};
+	}
+
+	private boolean listsEqual(List<?> a, List<?> b) {
+		for (Iterator<?> aIt = a.iterator(), bIt = b.iterator(); aIt.hasNext() && bIt.hasNext(); ) {
+			Object aObj = aIt.next();
+			if (!new EqualityChecker<>(aObj, this.exceptTypes, this.deepScanRecords, this.deepScanCollections).isEqual(
+				bIt.next())) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private static List<MethodHandle> createAccessors(Class<?> recordType) {
@@ -80,7 +119,9 @@ public class EqualityChecker<T> implements Predicate<T> {
 
 	private static MethodHandle lookupSafe(Method method) {
 		try {
-			return LOOKUP.unreflect(method);
+			// use the hammer to access methods in non-public records
+			var privateLookup = MethodHandles.privateLookupIn(method.getDeclaringClass(), LOOKUP);
+			return privateLookup.unreflect(method);
 		} catch (IllegalAccessException e) {
 			throw new AssertionError("Accessed " + method + " which is not accessible", e);
 		}


### PR DESCRIPTION
This allows to check records for "equality" deeply even if they have list or optionals containing records as record components