### PR TITLE
Semantic analysis

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -12,6 +12,9 @@
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CastToIncompatibleInterface" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ChainedEquality" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassCanBeRecord" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="myConversionStrategy" value="DO_NOT_SUGGEST" />
+    </inspection_tool>
     <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/qodana.yml
+++ b/qodana.yml
@@ -28,3 +28,4 @@ include:
 exclude:
   - name: JavaAnnotator # Counter - Hours wasted: 4
   - name: OptionalUsedAsFieldOrParameterType
+  - name: ClassCanBeRecord # Can't be configured adequately in here

--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -22,6 +22,8 @@ import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 
 public class GentleCompiler {
 
@@ -32,25 +34,28 @@ public class GentleCompiler {
 		LOGGER.info("Hello World, please be gentle UwU");
 		CommandArguments arguments = new CommandArgumentsParser().parseOrExit(args);
 
-		int flagsSet = 0;
+		Set<String> flagsSet = new HashSet<>();
 		if (arguments.echo()) {
-			flagsSet++;
+			flagsSet.add("echo");
 		}
 		if (arguments.lextest()) {
-			flagsSet++;
+			flagsSet.add("lextest");
 		}
 		if (arguments.parsetest()) {
-			flagsSet++;
+			flagsSet.add("parseTest");
 		}
 		if (arguments.printAst()) {
-			flagsSet++;
+			flagsSet.add("printAst");
 		}
 		if (arguments.check()) {
-			flagsSet++;
+			flagsSet.add("check");
 		}
 
-		if (flagsSet != 1) {
-			LOGGER.error("Conflicting flags");
+		if (flagsSet.isEmpty()) {
+			UserOutput.userError("No operation specified.");
+			System.exit(1);
+		} else if (flagsSet.size() != 1) {
+			UserOutput.userError("Conflicting flags set. Received the following mutually exclusive flags: " + flagsSet);
 			System.exit(1);
 		} else if (arguments.echo()) {
 			echoCommand(arguments.path());

--- a/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
@@ -11,20 +11,23 @@ import java.nio.file.Path;
 @Command(name = "gentle", description = "A small MiniJava compiler.", publicParser = true)
 public interface CommandArguments {
 
-	@Option(names = "--echo", description = "Reads the given file and will output it as it is.")
+	@Option(names = "--echo", description = "output the file as is")
 	boolean echo();
 
-	@Option(names = "--lextest", description = "Reads the given file and prints all tokens or aborts on first error")
+	@Option(names = "--lextest", description = "print all of the file's tokens")
 	boolean lextest();
 
-	@Option(names = "--parsetest", description = "Reads the given file and exits with 0 iff it is syntactically valid")
+	@Option(names = "--parsetest", description = "exit with 0 iff the file is syntactically valid")
 	boolean parsetest();
 
-	@Option(names = "--print-ast", description = "Reads the given file and pretty-prints the parser AST")
+	@Option(names = "--print-ast", description = "parse and pretty-print the file")
 	boolean printAst();
 
-	@Parameter(index = 0, converter = ExistingFileConverter.class, description = "The file to operate on.",
-		paramLabel = "PATH")
+	@Option(names = "--check", description = "exit with 0 iff the file is semantically valid")
+	boolean check();
+
+	@Parameter(index = 0, converter = ExistingFileConverter.class, description = "file to read and operate on",
+		paramLabel = "FILE")
 	Path path();
 
 	class ExistingFileConverter extends StringConverter<Path> {

--- a/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
+++ b/src/main/java/com/github/firmwehr/gentle/lexer/Lexer.java
@@ -58,7 +58,7 @@ public class Lexer {
 				}
 				continue;
 			}
-			tokens.add(readOperator("Expected an operator, integer, identifier or comment"));
+			tokens.add(readOperator("Expected keyword, operator, identifier, integer or comment"));
 		}
 		tokens.add(new EofToken(new SourceSpan(reader.getPosition(), reader.getPosition())));
 

--- a/src/main/java/com/github/firmwehr/gentle/lexer/LexerException.java
+++ b/src/main/java/com/github/firmwehr/gentle/lexer/LexerException.java
@@ -1,20 +1,22 @@
 package com.github.firmwehr.gentle.lexer;
 
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public class LexerException extends Exception {
 
 	private final Source source;
 	private final int offset;
+	private final String description;
 
-	public LexerException(String message, StringReader reader) {
-		super(message);
+	public LexerException(String description, StringReader reader) {
 		this.source = reader.getSource();
 		this.offset = reader.getPosition();
+		this.description = description;
 	}
 
 	@Override
 	public String getMessage() {
-		return source.formatErrorAt("Failed to lex token", offset, super.getMessage());
+		return "Failed to lex token\n" + source.formatMessageAt(new SourceSpan(offset, offset + 1), description);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ExprWithParens.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ExprWithParens.java
@@ -1,0 +1,16 @@
+package com.github.firmwehr.gentle.parser;
+
+import com.github.firmwehr.gentle.parser.ast.expression.Expression;
+import com.github.firmwehr.gentle.source.SourceSpan;
+
+/**
+ * An {@link Expression} that may or may not be surrounded by parentheses.
+ */
+public record ExprWithParens(
+	Expression expression,
+	SourceSpan parenSourceSpan
+) {
+	public ExprWithParens(Expression expression) {
+		this(expression, expression.sourceSpan());
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ParseException.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ParseException.java
@@ -16,6 +16,6 @@ public class ParseException extends Exception {
 
 	@Override
 	public String getMessage() {
-		return source.formatErrorAt("Unexpected " + token.format(), token.sourceSpan().startOffset(), description);
+		return "Unexpected " + token.format() + "\n" + source.formatMessageAt(token.sourceSpan(), description);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-@SuppressWarnings("ClassCanBeRecord")
 public class Parser {
 
 	private final Tokens tokens;

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -126,7 +126,7 @@ public class Parser {
 
 	private MainMethod parseMainMethodRest() throws ParseException {
 		tokens.expecting(ExpectedToken.STATIC).takeKeyword(Keyword.STATIC);
-		tokens.expecting(ExpectedToken.VOID).takeKeyword(Keyword.VOID);
+		Token voidToken = tokens.expecting(ExpectedToken.VOID).takeKeyword(Keyword.VOID);
 
 		Ident name = parseIdent();
 
@@ -139,7 +139,7 @@ public class Parser {
 
 		Block block = parseBlock();
 
-		return new MainMethod(name, parameter, block);
+		return new MainMethod(name, voidToken.sourceSpan(), parameter, block);
 	}
 
 	private Method parseMethodRest(Type type, Ident ident) throws ParseException {
@@ -216,10 +216,10 @@ public class Parser {
 		Type type = parseType();
 		Ident name = parseIdent();
 
-		Optional<Expression> value;
+		Optional<ExprWithParens> value;
 		if (tokens.expecting(ExpectedToken.ASSIGN).peek().isOperator(Operator.ASSIGN)) {
 			tokens.take();
-			value = Optional.of(parseExpression().expression());
+			value = Optional.of(parseExpression());
 		} else {
 			value = Optional.empty();
 		}

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -293,7 +293,7 @@ public class Parser {
 	}
 
 	private ReturnStatement parseReturnStatement() throws ParseException {
-		tokens.expecting(ExpectedToken.RETURN).takeKeyword(Keyword.RETURN);
+		Token start = tokens.expecting(ExpectedToken.RETURN).takeKeyword(Keyword.RETURN);
 
 		Optional<Expression> returnValue;
 		if (tokens.expecting(ExpectedToken.SEMICOLON).peek().isOperator(Operator.SEMICOLON)) {
@@ -302,9 +302,9 @@ public class Parser {
 			returnValue = Optional.of(parseExpression().expression());
 		}
 
-		tokens.expecting(ExpectedToken.SEMICOLON).takeOperator(Operator.SEMICOLON);
+		Token end = tokens.expecting(ExpectedToken.SEMICOLON).takeOperator(Operator.SEMICOLON);
 
-		return new ReturnStatement(returnValue);
+		return new ReturnStatement(returnValue, SourceSpan.from(start.sourceSpan(), end.sourceSpan()));
 	}
 
 	private ExpressionStatement parseExpressionStatement() throws ParseException {

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -530,22 +530,24 @@ public class Parser {
 				arrayLevel++;
 			}
 
+			SourceSpan typeSpan = SourceSpan.from(basicType.sourceSpan(), end.sourceSpan());
 			SourceSpan span = SourceSpan.from(start.sourceSpan(), end.sourceSpan());
-			return new NewArrayExpression(new Type(basicType, arrayLevel), size, span);
+			return new NewArrayExpression(new Type(basicType, arrayLevel, typeSpan), size, span);
 		}
 	}
 
 	private Type parseType() throws ParseException {
 		BasicType basicType = parseBasicType();
 
+		SourceSpan end = basicType.sourceSpan();
 		int arrayLevel = 0;
 		while (tokens.expecting(ExpectedToken.LEFT_BRACKET).peek().isOperator(Operator.LEFT_BRACKET)) {
 			tokens.take();
-			tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET);
+			end = tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET).sourceSpan();
 			arrayLevel++;
 		}
 
-		return new Type(basicType, arrayLevel);
+		return new Type(basicType, arrayLevel, SourceSpan.from(basicType.sourceSpan(), end));
 	}
 
 	private void expectingBasicType() {
@@ -560,9 +562,9 @@ public class Parser {
 		if (identToken.isPresent()) {
 			type = new IdentType(Ident.fromToken(identToken.get()));
 		} else if (token.isKeyword(Keyword.INT)) {
-			type = new IntType();
+			type = new IntType(token.sourceSpan());
 		} else if (token.isKeyword(Keyword.BOOLEAN)) {
-			type = new BooleanType();
+			type = new BooleanType(token.sourceSpan());
 		} else if (token.isKeyword(Keyword.VOID)) {
 			type = new VoidType(token.sourceSpan());
 		} else {

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -407,8 +407,10 @@ public class Parser {
 			Ident name = parseIdent();
 			if (tokens.expecting(ExpectedToken.LEFT_PAREN).peek().isOperator(Operator.LEFT_PAREN)) {
 				Pair<List<Expression>, SourceSpan> pair = parseParenthesisedArguments();
+				SourceSpan postfixSpan = SourceSpan.from(name.sourceSpan(), pair.second());
 				SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), pair.second());
-				return Optional.of(new MethodInvocationExpression(expression.expression(), name, pair.first(), span));
+				return Optional.of(
+					new MethodInvocationExpression(expression.expression(), name, pair.first(), postfixSpan, span));
 			} else {
 				SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), name.sourceSpan());
 				return Optional.of(new FieldAccessExpression(expression.expression(), name, span));

--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -47,7 +47,10 @@ import com.github.firmwehr.gentle.parser.tokens.Operator;
 import com.github.firmwehr.gentle.parser.tokens.OperatorToken;
 import com.github.firmwehr.gentle.parser.tokens.Token;
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceSpan;
+import com.github.firmwehr.gentle.util.Pair;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -216,7 +219,7 @@ public class Parser {
 		Optional<Expression> value;
 		if (tokens.expecting(ExpectedToken.ASSIGN).peek().isOperator(Operator.ASSIGN)) {
 			tokens.take();
-			value = Optional.of(parseExpression());
+			value = Optional.of(parseExpression().expression());
 		} else {
 			value = Optional.empty();
 		}
@@ -259,7 +262,7 @@ public class Parser {
 		tokens.expecting(ExpectedToken.IF).takeKeyword(Keyword.IF);
 		tokens.expecting(ExpectedToken.LEFT_PAREN).takeOperator(Operator.LEFT_PAREN);
 
-		Expression condition = parseExpression();
+		Expression condition = parseExpression().expression();
 
 		tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
 
@@ -280,7 +283,7 @@ public class Parser {
 		tokens.expecting(ExpectedToken.WHILE).takeKeyword(Keyword.WHILE);
 		tokens.expecting(ExpectedToken.LEFT_PAREN).takeOperator(Operator.LEFT_PAREN);
 
-		Expression condition = parseExpression();
+		Expression condition = parseExpression().expression();
 
 		tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
 
@@ -296,7 +299,7 @@ public class Parser {
 		if (tokens.expecting(ExpectedToken.SEMICOLON).peek().isOperator(Operator.SEMICOLON)) {
 			returnValue = Optional.empty();
 		} else {
-			returnValue = Optional.of(parseExpression());
+			returnValue = Optional.of(parseExpression().expression());
 		}
 
 		tokens.expecting(ExpectedToken.SEMICOLON).takeOperator(Operator.SEMICOLON);
@@ -305,11 +308,11 @@ public class Parser {
 	}
 
 	private ExpressionStatement parseExpressionStatement() throws ParseException {
-		Expression expression = parseExpression();
+		ExprWithParens expression = parseExpression();
 
 		tokens.expecting(ExpectedToken.SEMICOLON).takeOperator(Operator.SEMICOLON);
 
-		return new ExpressionStatement(expression);
+		return new ExpressionStatement(expression.expression());
 	}
 
 	private void expectingExpression() {
@@ -317,13 +320,13 @@ public class Parser {
 		tokens.expecting(ExpectedToken.LOGICAL_NOT).expecting(ExpectedToken.MINUS);
 	}
 
-	private Expression parseExpression() throws ParseException {
+	private ExprWithParens parseExpression() throws ParseException {
 		return parseExpressionWithPrecedence(0);
 	}
 
 	@SuppressWarnings("InfiniteRecursion")
-	private Expression parseExpressionWithPrecedence(int precedence) throws ParseException {
-		Expression expression = parseUnaryExpression();
+	private ExprWithParens parseExpressionWithPrecedence(int precedence) throws ParseException {
+		ExprWithParens expression = parseUnaryExpression();
 
 		while (true) {
 			Optional<BinaryOperator> operator = peekOptionalBinaryOperator();
@@ -343,9 +346,11 @@ public class Parser {
 				case LEFT -> opPrec + 1;
 				case RIGHT -> opPrec;
 			};
-			Expression rhs = parseExpressionWithPrecedence(newPrecedence);
+			ExprWithParens rhs = parseExpressionWithPrecedence(newPrecedence);
 
-			expression = new BinaryOperatorExpression(expression, rhs, operator.get());
+			SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), rhs.parenSourceSpan());
+			expression = new ExprWithParens(
+				new BinaryOperatorExpression(expression.expression(), rhs.expression(), operator.get(), span));
 		}
 
 		return expression;
@@ -360,26 +365,32 @@ public class Parser {
 		}
 	}
 
-	private Expression parseUnaryExpression() throws ParseException {
+	private ExprWithParens parseUnaryExpression() throws ParseException {
 		expectingExpression();
 		if (tokens.peek().isOperator(Operator.LOGICAL_NOT)) {
-			tokens.take();
-			return new UnaryOperatorExpression(UnaryOperator.LOGICAL_NOT, parseUnaryExpression());
+			Token start = tokens.take();
+			ExprWithParens expression = parseUnaryExpression();
+			SourceSpan span = SourceSpan.from(start.sourceSpan(), expression.parenSourceSpan());
+			return new ExprWithParens(
+				new UnaryOperatorExpression(UnaryOperator.LOGICAL_NOT, expression.expression(), span));
 		} else if (tokens.peek().isOperator(Operator.MINUS)) {
-			tokens.take();
-			return new UnaryOperatorExpression(UnaryOperator.NEGATION, parseUnaryExpression());
+			Token start = tokens.take();
+			ExprWithParens expression = parseUnaryExpression();
+			SourceSpan span = SourceSpan.from(start.sourceSpan(), expression.parenSourceSpan());
+			return new ExprWithParens(
+				new UnaryOperatorExpression(UnaryOperator.NEGATION, expression.expression(), span));
 		} else {
 			return parsePostfixExpression();
 		}
 	}
 
-	private Expression parsePostfixExpression() throws ParseException {
-		Expression expression = parsePrimaryExpression();
+	private ExprWithParens parsePostfixExpression() throws ParseException {
+		ExprWithParens expression = parsePrimaryExpression();
 
 		while (true) {
 			Optional<Expression> postfixedExpression = parseOptionalPostfixOp(expression);
 			if (postfixedExpression.isPresent()) {
-				expression = postfixedExpression.get();
+				expression = new ExprWithParens(postfixedExpression.get());
 			} else {
 				break;
 			}
@@ -388,43 +399,47 @@ public class Parser {
 		return expression;
 	}
 
-	private Optional<Expression> parseOptionalPostfixOp(Expression expression) throws ParseException {
+	private Optional<Expression> parseOptionalPostfixOp(ExprWithParens expression) throws ParseException {
 		Token token = tokens.expecting(ExpectedToken.DOT).expecting(ExpectedToken.LEFT_BRACKET).peek();
 
 		if (token.isOperator(Operator.DOT)) {
 			tokens.take();
 			Ident name = parseIdent();
 			if (tokens.expecting(ExpectedToken.LEFT_PAREN).peek().isOperator(Operator.LEFT_PAREN)) {
-				return Optional.of(new MethodInvocationExpression(expression, name, parseParenthesisedArguments()));
+				Pair<List<Expression>, SourceSpan> pair = parseParenthesisedArguments();
+				SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), pair.second());
+				return Optional.of(new MethodInvocationExpression(expression.expression(), name, pair.first(), span));
 			} else {
-				return Optional.of(new FieldAccessExpression(expression, name));
+				SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), name.sourceSpan());
+				return Optional.of(new FieldAccessExpression(expression.expression(), name, span));
 			}
 		} else if (token.isOperator(Operator.LEFT_BRACKET)) {
 			tokens.take();
-			Expression index = parseExpression();
-			tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET);
-			return Optional.of(new ArrayAccessExpression(expression, index));
+			Expression index = parseExpression().expression();
+			Token end = tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET);
+			SourceSpan span = SourceSpan.from(expression.parenSourceSpan(), end.sourceSpan());
+			return Optional.of(new ArrayAccessExpression(expression.expression(), index, span));
 		} else {
 			return Optional.empty();
 		}
 	}
 
-	private List<Expression> parseParenthesisedArguments() throws ParseException {
-		tokens.expecting(ExpectedToken.LEFT_PAREN).takeOperator(Operator.LEFT_PAREN);
+	private Pair<List<Expression>, SourceSpan> parseParenthesisedArguments() throws ParseException {
+		Token start = tokens.expecting(ExpectedToken.LEFT_PAREN).takeOperator(Operator.LEFT_PAREN);
 
 		List<Expression> arguments = new ArrayList<>();
 		if (!tokens.expecting(ExpectedToken.RIGHT_PAREN).peek().isOperator(Operator.RIGHT_PAREN)) {
-			arguments.add(parseExpression());
+			arguments.add(parseExpression().expression());
 
 			while (tokens.expecting(ExpectedToken.COMMA).peek().isOperator(Operator.COMMA)) {
 				tokens.take();
-				arguments.add(parseExpression());
+				arguments.add(parseExpression().expression());
 			}
 		}
 
-		tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
+		Token end = tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
 
-		return arguments;
+		return new Pair<>(arguments, SourceSpan.from(start.sourceSpan(), end.sourceSpan()));
 	}
 
 	private void expectingPrimaryExpression() {
@@ -437,7 +452,7 @@ public class Parser {
 			.expecting(ExpectedToken.NEW);
 	}
 
-	private Expression parsePrimaryExpression() throws ParseException {
+	private ExprWithParens parsePrimaryExpression() throws ParseException {
 		expectingPrimaryExpression();
 
 		Token token = tokens.peek();
@@ -446,40 +461,44 @@ public class Parser {
 
 		if (token.isKeyword(Keyword.NULL)) {
 			tokens.take();
-			return new NullExpression();
+			return new ExprWithParens(new NullExpression(token.sourceSpan()));
 		} else if (token.isKeyword(Keyword.TRUE)) {
 			tokens.take();
-			return new BooleanLiteralExpression(true);
+			return new ExprWithParens(new BooleanLiteralExpression(true, token.sourceSpan()));
 		} else if (token.isKeyword(Keyword.FALSE)) {
 			tokens.take();
-			return new BooleanLiteralExpression(false);
+			return new ExprWithParens(new BooleanLiteralExpression(false, token.sourceSpan()));
 		} else if (integerLiteralToken.isPresent()) {
 			tokens.take();
-			return new IntegerLiteralExpression(integerLiteralToken.get().value());
+			BigInteger value = integerLiteralToken.get().value();
+			return new ExprWithParens(new IntegerLiteralExpression(value, token.sourceSpan()));
 		} else if (identToken.isPresent()) {
 			tokens.take();
+			Ident name = Ident.fromToken(identToken.get());
 			if (tokens.expecting(ExpectedToken.LEFT_PAREN).peek().isOperator(Operator.LEFT_PAREN)) {
-				return new LocalMethodCallExpression(Ident.fromToken(identToken.get()), parseParenthesisedArguments());
+				Pair<List<Expression>, SourceSpan> pair = parseParenthesisedArguments();
+				SourceSpan span = SourceSpan.from(name.sourceSpan(), pair.second());
+				return new ExprWithParens(new LocalMethodCallExpression(name, pair.first(), span));
 			} else {
-				return new IdentExpression(Ident.fromToken(identToken.get()));
+				return new ExprWithParens(new IdentExpression(name));
 			}
 		} else if (token.isKeyword(Keyword.THIS)) {
 			tokens.take();
-			return new ThisExpression();
+			return new ExprWithParens(new ThisExpression(token.sourceSpan()));
 		} else if (token.isOperator(Operator.LEFT_PAREN)) {
-			tokens.take();
-			Expression expression = parseExpression();
-			tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
-			return expression;
+			Token start = tokens.take();
+			Expression expression = parseExpression().expression();
+			Token end = tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
+			return new ExprWithParens(expression, SourceSpan.from(start.sourceSpan(), end.sourceSpan()));
 		} else if (token.isKeyword(Keyword.NEW)) {
-			return parseNewObjectExpressionOrNewArrayExpression();
+			return new ExprWithParens(parseNewObjectExpressionOrNewArrayExpression());
 		} else {
 			return tokens.error();
 		}
 	}
 
 	private Expression parseNewObjectExpressionOrNewArrayExpression() throws ParseException {
-		tokens.expecting(ExpectedToken.NEW).takeKeyword(Keyword.NEW);
+		Token start = tokens.expecting(ExpectedToken.NEW).takeKeyword(Keyword.NEW);
 
 		Token token = tokens.expecting(ExpectedToken.IDENTIFIER).expecting(ExpectedToken.BASIC_TYPE).peek();
 		Optional<IdentToken> identToken = token.asIdentToken();
@@ -488,13 +507,13 @@ public class Parser {
 			tokens.take();
 			Ident name = Ident.fromToken(identToken.get());
 			tokens.expecting(ExpectedToken.LEFT_PAREN).takeOperator(Operator.LEFT_PAREN);
-			tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
-			return new NewObjectExpression(name);
+			Token end = tokens.expecting(ExpectedToken.RIGHT_PAREN).takeOperator(Operator.RIGHT_PAREN);
+			return new NewObjectExpression(name, SourceSpan.from(start.sourceSpan(), end.sourceSpan()));
 		} else {
 			BasicType basicType = parseBasicType();
 			tokens.expecting(ExpectedToken.LEFT_BRACKET).takeOperator(Operator.LEFT_BRACKET);
-			Expression size = parseExpression();
-			tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET);
+			Expression size = parseExpression().expression();
+			Token end = tokens.expecting(ExpectedToken.RIGHT_BRACKET).takeOperator(Operator.RIGHT_BRACKET);
 
 			int arrayLevel = 1;
 			// This loop checks for the closing bracket in addition to the opening bracket because if there is
@@ -507,11 +526,12 @@ public class Parser {
 				tokens.peek(1).isOperator(Operator.RIGHT_BRACKET)) {
 
 				tokens.take();
-				tokens.take();
+				end = tokens.take();
 				arrayLevel++;
 			}
 
-			return new NewArrayExpression(new Type(basicType, arrayLevel), size);
+			SourceSpan span = SourceSpan.from(start.sourceSpan(), end.sourceSpan());
+			return new NewArrayExpression(new Type(basicType, arrayLevel), size, span);
 		}
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/Tokens.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Tokens.java
@@ -5,7 +5,9 @@ import com.github.firmwehr.gentle.lexer.LexerException;
 import com.github.firmwehr.gentle.parser.tokens.EofToken;
 import com.github.firmwehr.gentle.parser.tokens.IdentToken;
 import com.github.firmwehr.gentle.parser.tokens.Keyword;
+import com.github.firmwehr.gentle.parser.tokens.KeywordToken;
 import com.github.firmwehr.gentle.parser.tokens.Operator;
+import com.github.firmwehr.gentle.parser.tokens.OperatorToken;
 import com.github.firmwehr.gentle.parser.tokens.Token;
 import com.github.firmwehr.gentle.source.Source;
 
@@ -77,29 +79,36 @@ public class Tokens {
 		return this;
 	}
 
-	public void take() {
+	public Token take() {
+		Token token = peek();
+
 		if (index < tokens.size()) {
 			index++;
 		}
 		expectedTokensAtIndex.clear();
+
+		return token;
 	}
 
 
-	public void takeKeyword(Keyword keyword) throws ParseException {
-		if (peek().isKeyword(keyword)) {
+	public KeywordToken takeKeyword(Keyword keyword) throws ParseException {
+		if (peek() instanceof KeywordToken t && t.isKeyword(keyword)) {
 			take();
+			return t;
 		} else {
-			error();
+			return error();
 		}
 	}
 
-	public void takeOperator(Operator operator) throws ParseException {
-		if (peek().isOperator(operator)) {
+	public OperatorToken takeOperator(Operator operator) throws ParseException {
+		if (peek() instanceof OperatorToken t && t.isOperator(operator)) {
 			take();
+			return t;
 		} else {
-			error();
+			return error();
 		}
 	}
+
 
 	public IdentToken takeIdent() throws ParseException {
 		Optional<IdentToken> identToken = peek().asIdentToken();

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Ident.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Ident.java
@@ -17,7 +17,7 @@ public record Ident(
 	 * A dummy identifier with bogus SourcePosition, meant only to be used in tests.
 	 */
 	public static Ident dummy(String name) {
-		return new Ident(name, new SourceSpan(0, 0));
+		return new Ident(name, SourceSpan.dummy());
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/MainMethod.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/MainMethod.java
@@ -4,19 +4,21 @@ import com.github.firmwehr.gentle.parser.ast.statement.Block;
 import com.github.firmwehr.gentle.parser.ast.statement.Statement;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrint;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record MainMethod(
 	Ident name,
+	SourceSpan voidSpan,
 	Parameter parameter,
 	Block body
 ) implements PrettyPrint {
 	public static MainMethod dummy(String name, Type paramType, String paramName) {
-		return new MainMethod(Ident.dummy(name), new Parameter(paramType, Ident.dummy(paramName)),
+		return new MainMethod(Ident.dummy(name), SourceSpan.dummy(), new Parameter(paramType, Ident.dummy(paramName)),
 			Statement.newBlock());
 	}
 
 	public MainMethod withBody(Block body) {
-		return new MainMethod(name, parameter, body);
+		return new MainMethod(name, voidSpan, parameter, body);
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
@@ -12,30 +12,31 @@ import com.google.common.base.Preconditions;
 
 public record Type(
 	BasicType basicType,
-	int arrayLevel
+	int arrayLevel,
+	SourceSpan sourceSpan
 ) implements PrettyPrint {
 	public Type {
 		Preconditions.checkArgument(arrayLevel >= 0);
 	}
 
 	public static Type newBool() {
-		return new Type(new BooleanType(), 0);
+		return new Type(new BooleanType(SourceSpan.dummy()), 0, SourceSpan.dummy());
 	}
 
 	public static Type newIdent(String name) {
-		return new Type(new IdentType(Ident.dummy(name)), 0);
+		return new Type(new IdentType(Ident.dummy(name)), 0, SourceSpan.dummy());
 	}
 
 	public static Type newInt() {
-		return new Type(new IntType(), 0);
+		return new Type(new IntType(SourceSpan.dummy()), 0, SourceSpan.dummy());
 	}
 
 	public static Type newVoid() {
-		return new Type(new VoidType(SourceSpan.dummy()), 0);
+		return new Type(new VoidType(SourceSpan.dummy()), 0, SourceSpan.dummy());
 	}
 
 	public Type atLevel(int level) {
-		return new Type(basicType, level);
+		return new Type(basicType, level, SourceSpan.dummy());
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
@@ -31,7 +31,7 @@ public record Type(
 	}
 
 	public static Type newVoid() {
-		return new Type(new VoidType(new SourceSpan(0, 0)), 0);
+		return new Type(new VoidType(SourceSpan.dummy()), 0);
 	}
 
 	public Type atLevel(int level) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BasicType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BasicType.java
@@ -1,7 +1,9 @@
 package com.github.firmwehr.gentle.parser.ast.basictype;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrint;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public sealed interface BasicType extends PrettyPrint permits IntType, BooleanType, VoidType, IdentType {
+	SourceSpan sourceSpan();
 }
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BooleanType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BooleanType.java
@@ -1,8 +1,9 @@
 package com.github.firmwehr.gentle.parser.ast.basictype;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record BooleanType() implements BasicType {
+public record BooleanType(SourceSpan sourceSpan) implements BasicType {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add("boolean");

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IdentType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IdentType.java
@@ -2,10 +2,16 @@ package com.github.firmwehr.gentle.parser.ast.basictype;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record IdentType(Ident name) implements BasicType {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add(name);
+	}
+
+	@Override
+	public SourceSpan sourceSpan() {
+		return name.sourceSpan();
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IntType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IntType.java
@@ -1,8 +1,9 @@
 package com.github.firmwehr.gentle.parser.ast.basictype;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record IntType() implements BasicType {
+public record IntType(SourceSpan sourceSpan) implements BasicType {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add("int");

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ArrayAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ArrayAccessExpression.java
@@ -1,10 +1,12 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record ArrayAccessExpression(
 	Expression expression,
-	Expression index
+	Expression index,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BinaryOperatorExpression.java
@@ -1,11 +1,13 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record BinaryOperatorExpression(
 	Expression lhs,
 	Expression rhs,
-	BinaryOperator operator
+	BinaryOperator operator,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BooleanLiteralExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BooleanLiteralExpression.java
@@ -1,8 +1,12 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record BooleanLiteralExpression(boolean value) implements Expression {
+public record BooleanLiteralExpression(
+	boolean value,
+	SourceSpan sourceSpan
+) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		if (value) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/Expression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/Expression.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.ast.Type;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrint;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -12,12 +13,14 @@ public sealed interface Expression extends PrettyPrint
 	        IdentExpression, IntegerLiteralExpression, LocalMethodCallExpression, MethodInvocationExpression,
 	        NewArrayExpression, NewObjectExpression, NullExpression, ThisExpression, UnaryOperatorExpression {
 
+	SourceSpan sourceSpan();
+
 	static BinaryOperatorExpression newBinOp(Expression lhs, Expression rhs, BinaryOperator operator) {
-		return new BinaryOperatorExpression(lhs, rhs, operator);
+		return new BinaryOperatorExpression(lhs, rhs, operator, SourceSpan.dummy());
 	}
 
 	static BooleanLiteralExpression newBool(boolean value) {
-		return new BooleanLiteralExpression(value);
+		return new BooleanLiteralExpression(value, SourceSpan.dummy());
 	}
 
 	static IdentExpression newIdent(String name) {
@@ -25,42 +28,42 @@ public sealed interface Expression extends PrettyPrint
 	}
 
 	static IntegerLiteralExpression newInt(long value) {
-		return new IntegerLiteralExpression(BigInteger.valueOf(value));
+		return new IntegerLiteralExpression(BigInteger.valueOf(value), SourceSpan.dummy());
 	}
 
 	static LocalMethodCallExpression newCall(String name, Expression... arguments) {
-		return new LocalMethodCallExpression(Ident.dummy(name), Arrays.asList(arguments));
+		return new LocalMethodCallExpression(Ident.dummy(name), Arrays.asList(arguments), SourceSpan.dummy());
 	}
 
 	static NewArrayExpression newNewArray(Type type, Expression size) {
-		return new NewArrayExpression(type, size);
+		return new NewArrayExpression(type, size, SourceSpan.dummy());
 	}
 
 	static NewObjectExpression newNewObject(String name) {
-		return new NewObjectExpression(Ident.dummy(name));
+		return new NewObjectExpression(Ident.dummy(name), SourceSpan.dummy());
 	}
 
 	static NullExpression newNull() {
-		return new NullExpression();
+		return new NullExpression(SourceSpan.dummy());
 	}
 
 	static ThisExpression newThis() {
-		return new ThisExpression();
+		return new ThisExpression(SourceSpan.dummy());
 	}
 
 	default UnaryOperatorExpression withUnary(UnaryOperator operator) {
-		return new UnaryOperatorExpression(operator, this);
+		return new UnaryOperatorExpression(operator, this, SourceSpan.dummy());
 	}
 
 	default MethodInvocationExpression withCall(String name, Expression... arguments) {
-		return new MethodInvocationExpression(this, Ident.dummy(name), Arrays.asList(arguments));
+		return new MethodInvocationExpression(this, Ident.dummy(name), Arrays.asList(arguments), SourceSpan.dummy());
 	}
 
 	default ArrayAccessExpression withArrayAccess(Expression index) {
-		return new ArrayAccessExpression(this, index);
+		return new ArrayAccessExpression(this, index, SourceSpan.dummy());
 	}
 
 	default FieldAccessExpression withFieldAccess(String name) {
-		return new FieldAccessExpression(this, Ident.dummy(name));
+		return new FieldAccessExpression(this, Ident.dummy(name), SourceSpan.dummy());
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/Expression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/Expression.java
@@ -56,7 +56,8 @@ public sealed interface Expression extends PrettyPrint
 	}
 
 	default MethodInvocationExpression withCall(String name, Expression... arguments) {
-		return new MethodInvocationExpression(this, Ident.dummy(name), Arrays.asList(arguments), SourceSpan.dummy());
+		return new MethodInvocationExpression(this, Ident.dummy(name), Arrays.asList(arguments), SourceSpan.dummy(),
+			SourceSpan.dummy());
 	}
 
 	default ArrayAccessExpression withArrayAccess(Expression index) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/FieldAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/FieldAccessExpression.java
@@ -2,10 +2,12 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record FieldAccessExpression(
 	Expression expression,
-	Ident name
+	Ident name,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IdentExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IdentExpression.java
@@ -2,10 +2,16 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record IdentExpression(Ident name) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add(name);
+	}
+
+	@Override
+	public SourceSpan sourceSpan() {
+		return name.sourceSpan();
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IntegerLiteralExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IntegerLiteralExpression.java
@@ -1,10 +1,14 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.math.BigInteger;
 
-public record IntegerLiteralExpression(BigInteger value) implements Expression {
+public record IntegerLiteralExpression(
+	BigInteger value,
+	SourceSpan sourceSpan
+) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add(value.toString());

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/LocalMethodCallExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/LocalMethodCallExpression.java
@@ -2,12 +2,14 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.List;
 
 public record LocalMethodCallExpression(
 	Ident name,
-	List<Expression> arguments
+	List<Expression> arguments,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
@@ -2,13 +2,15 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.List;
 
 public record MethodInvocationExpression(
 	Expression expression,
 	Ident name,
-	List<Expression> arguments
+	List<Expression> arguments,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
@@ -10,6 +10,7 @@ public record MethodInvocationExpression(
 	Expression expression,
 	Ident name,
 	List<Expression> arguments,
+	SourceSpan postfixSpan,
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewArrayExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewArrayExpression.java
@@ -2,11 +2,13 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Type;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 import com.google.common.base.Preconditions;
 
 public record NewArrayExpression(
 	Type type,
-	Expression size
+	Expression size,
+	SourceSpan sourceSpan
 ) implements Expression {
 	public NewArrayExpression {
 		Preconditions.checkArgument(type.arrayLevel() >= 1);

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewObjectExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewObjectExpression.java
@@ -2,8 +2,12 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record NewObjectExpression(Ident name) implements Expression {
+public record NewObjectExpression(
+	Ident name,
+	SourceSpan sourceSpan
+) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		if (!omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NullExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NullExpression.java
@@ -1,8 +1,11 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record NullExpression() implements Expression {
+public record NullExpression(
+	SourceSpan sourceSpan
+) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add("null");

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ThisExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ThisExpression.java
@@ -1,8 +1,11 @@
 package com.github.firmwehr.gentle.parser.ast.expression;
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
-public record ThisExpression() implements Expression {
+public record ThisExpression(
+	SourceSpan sourceSpan
+) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add("this");

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/UnaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/UnaryOperatorExpression.java
@@ -2,10 +2,12 @@ package com.github.firmwehr.gentle.parser.ast.expression;
 
 
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record UnaryOperatorExpression(
 	UnaryOperator operator,
-	Expression expression
+	Expression expression,
+	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Block.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Block.java
@@ -1,5 +1,6 @@
 package com.github.firmwehr.gentle.parser.ast.statement;
 
+import com.github.firmwehr.gentle.parser.ExprWithParens;
 import com.github.firmwehr.gentle.parser.Util;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.ast.Type;
@@ -20,7 +21,8 @@ public record Block(List<BlockStatement> statements) implements Statement, Block
 	}
 
 	public Block thenLocalVar(Type type, String name, Expression value) {
-		return then(new LocalVariableDeclarationStatement(type, Ident.dummy(name), Optional.of(value)));
+		return then(
+			new LocalVariableDeclarationStatement(type, Ident.dummy(name), Optional.of(new ExprWithParens(value))));
 	}
 
 	public Block thenBlock(Block block) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/LocalVariableDeclarationStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/LocalVariableDeclarationStatement.java
@@ -1,8 +1,8 @@
 package com.github.firmwehr.gentle.parser.ast.statement;
 
+import com.github.firmwehr.gentle.parser.ExprWithParens;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.parser.ast.Type;
-import com.github.firmwehr.gentle.parser.ast.expression.Expression;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
 
 import java.util.Optional;
@@ -10,12 +10,12 @@ import java.util.Optional;
 public record LocalVariableDeclarationStatement(
 	Type type,
 	Ident name,
-	Optional<Expression> value
+	Optional<ExprWithParens> value
 ) implements BlockStatement {
 	@Override
 	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
 		p.add(type).add(" ").add(name);
-		value.ifPresent(expression -> p.add(" = ").add(expression, true));
+		value.ifPresent(pair -> p.add(" = ").add(pair.expression(), true));
 		p.add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ReturnStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ReturnStatement.java
@@ -2,10 +2,14 @@ package com.github.firmwehr.gentle.parser.ast.statement;
 
 import com.github.firmwehr.gentle.parser.ast.expression.Expression;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrinter;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record ReturnStatement(Optional<Expression> returnValue) implements Statement, BlockStatement {
+public record ReturnStatement(
+	Optional<Expression> returnValue,
+	SourceSpan sourceSpan
+) implements Statement, BlockStatement {
 	@Override
 	public BlockStatement asBlockStatement() {
 		return this;

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Statement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Statement.java
@@ -2,6 +2,7 @@ package com.github.firmwehr.gentle.parser.ast.statement;
 
 import com.github.firmwehr.gentle.parser.ast.expression.Expression;
 import com.github.firmwehr.gentle.parser.prettyprint.PrettyPrint;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,11 +31,11 @@ public sealed interface Statement extends PrettyPrint
 	}
 
 	static ReturnStatement newReturn() {
-		return new ReturnStatement(Optional.empty());
+		return new ReturnStatement(Optional.empty(), SourceSpan.dummy());
 	}
 
 	static ReturnStatement newReturn(Expression returnValue) {
-		return new ReturnStatement(Optional.of(returnValue));
+		return new ReturnStatement(Optional.of(returnValue), SourceSpan.dummy());
 	}
 
 	static WhileStatement newWhile(Expression condition, Statement body) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -72,7 +72,7 @@ public record FunctionScope(
 
 		StackedNamespace<LocalVariableDeclaration> localVariables = new StackedNamespace<>(source);
 		for (LocalVariableDeclaration parameter : method.parameters()) {
-			localVariables.put(parameter.getDeclaration(), parameter);
+			localVariables.put(parameter.declaration(), parameter);
 		}
 
 		return new FunctionScope(source, classes, currentClass, localVariables);
@@ -130,7 +130,7 @@ public record FunctionScope(
 		LocalVariableDeclaration decl =
 			new LocalVariableDeclaration(type, statement.type().sourceSpan(), statement.name());
 
-		localVariables.put(decl.getDeclaration(), decl);
+		localVariables.put(decl.declaration(), decl);
 
 		if (statement.value().isPresent()) {
 			SExpression lhs = new SLocalVariableExpression(decl, statement.name().sourceSpan());

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -43,6 +43,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SBooleanValueExpressio
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
@@ -237,8 +238,17 @@ public record FunctionScope(
 		return new SFieldAccessExpression(expression, field);
 	}
 
-	SExpression convert(IdentExpression expr) {
-		return null; // TODO Implement
+	SExpression convert(IdentExpression expr) throws SemanticException {
+		if (currentClass.isPresent()) {
+			if (localVariables.getOpt(expr.name()).isPresent()) {
+				return new SLocalVariableExpression(localVariables.getOpt(expr.name()).get());
+			} else {
+				SField field = currentClass.get().fields().get(expr.name());
+				return new SFieldAccessExpression(new SThisExpression(currentClass.get()), field);
+			}
+		} else {
+			return new SLocalVariableExpression(localVariables().get(expr.name()));
+		}
 	}
 
 	SExpression convert(IntegerLiteralExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -42,6 +42,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpress
 import com.github.firmwehr.gentle.semantic.ast.expression.SBooleanValueExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SIntegerValueExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
@@ -251,8 +252,13 @@ public record FunctionScope(
 		}
 	}
 
-	SExpression convert(IntegerLiteralExpression expr) {
-		return null; // TODO Implement
+	SIntegerValueExpression convert(IntegerLiteralExpression expr) throws SemanticException {
+		try {
+			return new SIntegerValueExpression(expr.value().intValueExact());
+		} catch (ArithmeticException e) {
+			// TODO Get rid of null here
+			throw new SemanticException(source, null, "integer literal too large");
+		}
 	}
 
 	SExpression convert(LocalMethodCallExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -86,7 +86,7 @@ public record FunctionScope(
 		for (BlockStatement statement : block.statements()) {
 			switch (statement) {
 				case Block s -> statements.add(convert(s));
-				case EmptyStatement s -> {
+				case EmptyStatement ignored -> {
 				}
 				case ExpressionStatement s -> statements.add(convert(s));
 				case IfStatement s -> statements.add(convert(s));
@@ -103,7 +103,7 @@ public record FunctionScope(
 	public SStatement convert(Statement statement) throws SemanticException {
 		return switch (statement) {
 			case Block s -> convert(s);
-			case EmptyStatement s -> new SBlock();
+			case EmptyStatement ignored -> new SBlock();
 			case ExpressionStatement s -> convert(s);
 			case IfStatement s -> convert(s);
 			case ReturnStatement s -> convert(s);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -202,9 +202,7 @@ public record FunctionScope(
 		};
 
 		if (type.isEmpty()) {
-			// TODO Give expressions a SourceSpan
-			// TODO Get rid of null here
-			throw new SemanticException(source, null, "expected array");
+			throw new SemanticException(source, expr.sourceSpan(), "expected array");
 		}
 
 		return new SArrayAccessExpression(expression, index, type.get());
@@ -233,8 +231,7 @@ public record FunctionScope(
 
 		Optional<SClassType> classType = typeToClassType(expression.type());
 		if (classType.isEmpty()) {
-			// TODO Get rid of null here
-			throw new SemanticException(source, null, "expected object");
+			throw new SemanticException(source, expr.sourceSpan(), "expected object");
 		}
 
 		SField field = classType.get().classDecl().fields().get(expr.name());
@@ -259,8 +256,7 @@ public record FunctionScope(
 		try {
 			return new SIntegerValueExpression(expr.value().intValueExact());
 		} catch (ArithmeticException e) {
-			// TODO Get rid of null here
-			throw new SemanticException(source, null, "integer literal too large");
+			throw new SemanticException(source, expr.sourceSpan(), "integer literal too large");
 		}
 	}
 
@@ -287,8 +283,7 @@ public record FunctionScope(
 
 		Optional<SClassType> classType = typeToClassType(expression.type());
 		if (classType.isEmpty()) {
-			// TODO Get rid of null here
-			throw new SemanticException(source, null, "expected object");
+			throw new SemanticException(source, expr.sourceSpan(), "expected object");
 		}
 
 		SMethod method = classType.get().classDecl().methods().get(expr.name());
@@ -318,8 +313,7 @@ public record FunctionScope(
 
 	SThisExpression convert(ThisExpression expr) throws SemanticException {
 		if (currentClass.isEmpty()) {
-			// TODO Get rid of null here
-			throw new SemanticException(source, null, "using 'this' in static context");
+			throw new SemanticException(source, expr.sourceSpan(), "using 'this' in static context");
 		}
 
 		return new SThisExpression(currentClass.get());

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -187,6 +187,7 @@ public record FunctionScope(
 			default -> Optional.empty();
 		};
 
+		//noinspection ConstantConditions
 		if (type.isEmpty()) {
 			throw new SemanticException(source, expr.sourceSpan(), "expected array");
 		}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -76,8 +76,9 @@ public record FunctionScope(
 	}
 
 	public SBlock convert(Block block) throws SemanticException {
-		List<SStatement> statements = new ArrayList<>();
+		localVariables.enterScope();
 
+		List<SStatement> statements = new ArrayList<>();
 		for (BlockStatement statement : block.statements()) {
 			switch (statement) {
 				case Block s -> statements.add(convert(s));
@@ -91,6 +92,7 @@ public record FunctionScope(
 			}
 		}
 
+		localVariables.leaveScope();
 		return new SBlock(statements);
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -315,8 +315,13 @@ public record FunctionScope(
 		return new SNullExpression();
 	}
 
-	SExpression convert(ThisExpression expr) {
-		return null; // TODO Implement
+	SThisExpression convert(ThisExpression expr) throws SemanticException {
+		if (currentClass.isEmpty()) {
+			// TODO Get rid of null here
+			throw new SemanticException(source, null, "using 'this' in static context");
+		}
+
+		return new SThisExpression(currentClass.get());
 	}
 
 	SExpression convert(UnaryOperatorExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -47,6 +47,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpressi
 import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNullExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
@@ -310,8 +311,8 @@ public record FunctionScope(
 		return new SNewObjectExpression(classes.get(expr.name()));
 	}
 
-	SExpression convert(NullExpression expr) {
-		return null; // TODO Implement
+	SNullExpression convert(NullExpression expr) {
+		return new SNullExpression();
 	}
 
 	SExpression convert(ThisExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -14,6 +14,7 @@ import com.github.firmwehr.gentle.parser.ast.expression.NewArrayExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.NewObjectExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.NullExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.ThisExpression;
+import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperatorExpression;
 import com.github.firmwehr.gentle.parser.ast.statement.Block;
 import com.github.firmwehr.gentle.parser.ast.statement.BlockStatement;
@@ -311,7 +312,15 @@ public record FunctionScope(
 		return new SThisExpression(currentClass.get(), expr.sourceSpan());
 	}
 
-	SUnaryOperatorExpression convert(UnaryOperatorExpression expr) throws SemanticException {
+	SExpression convert(UnaryOperatorExpression expr) throws SemanticException {
+		if (expr.operator() == UnaryOperator.NEGATION && expr.expression() instanceof IntegerLiteralExpression i) {
+			try {
+				return new SIntegerValueExpression(i.value().negate().intValueExact(), expr.sourceSpan());
+			} catch (ArithmeticException e) {
+				throw new SemanticException(source, expr.sourceSpan(), "integer literal too small");
+			}
+		}
+
 		return new SUnaryOperatorExpression(expr.operator(), convert(expr.expression()), expr.sourceSpan());
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -46,6 +46,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SIntegerValueExpressio
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
@@ -305,8 +306,8 @@ public record FunctionScope(
 		return new SNewArrayExpression(convertNormal(expr.type()), convert(expr.size()));
 	}
 
-	SExpression convert(NewObjectExpression expr) {
-		return null; // TODO Implement
+	SNewObjectExpression convert(NewObjectExpression expr) throws SemanticException {
+		return new SNewObjectExpression(classes.get(expr.name()));
 	}
 
 	SExpression convert(NullExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -266,7 +266,7 @@ public record FunctionScope(
 		// The SThisExpression doesn't really have a proper SourceSpan. Giving it the SMethodInvocationExpression's
 		// span probably makes the most sense.
 		return new SMethodInvocationExpression(new SThisExpression(currentClass.get(), expr.sourceSpan()), method,
-			arguments, expr.sourceSpan());
+			arguments, expr.sourceSpan(), expr.sourceSpan());
 	}
 
 	SMethodInvocationExpression convert(MethodInvocationExpression expr) throws SemanticException {
@@ -287,7 +287,7 @@ public record FunctionScope(
 			arguments.add(convert(argument));
 		}
 
-		return new SMethodInvocationExpression(expression, method, arguments, expr.sourceSpan());
+		return new SMethodInvocationExpression(expression, method, arguments, expr.postfixSpan(), expr.sourceSpan());
 	}
 
 	SNewArrayExpression convert(NewArrayExpression expr) throws SemanticException {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -232,7 +232,7 @@ public record FunctionScope(
 					expr.sourceSpan());
 			}
 		} else {
-			return new SLocalVariableExpression(localVariables().get(expr.name()), expr.sourceSpan());
+			return new SLocalVariableExpression(localVariables.get(expr.name()), expr.sourceSpan());
 		}
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -180,6 +180,7 @@ public record FunctionScope(
 		SExpression expression = convert(expr.expression());
 		SExpression index = convert(expr.index());
 
+		//noinspection SwitchStatementWithTooFewBranches
 		Optional<SNormalType> type = switch (expression.type()) {
 			case SNormalType t -> t.withDecrementedLevel();
 			default -> Optional.empty();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -31,6 +31,7 @@ import com.github.firmwehr.gentle.parser.ast.statement.Statement;
 import com.github.firmwehr.gentle.parser.ast.statement.WhileStatement;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
+import com.github.firmwehr.gentle.semantic.ast.SField;
 import com.github.firmwehr.gentle.semantic.ast.SMethod;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SBasicType;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
@@ -40,6 +41,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression
 import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SBooleanValueExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
@@ -219,8 +221,20 @@ public record FunctionScope(
 		return new SBooleanValueExpression(expr.value());
 	}
 
-	SExpression convert(FieldAccessExpression expr) {
-		return null; // TODO Implement
+	SFieldAccessExpression convert(FieldAccessExpression expr) throws SemanticException {
+		SExpression expression = convert(expr.expression());
+
+		SField field;
+		if (expression.type() instanceof SNormalType t && t.arrayLevel() == 0 &&
+			t.basicType() instanceof SClassType classType) {
+
+			field = classType.classDecl().fields().get(expr.name());
+		} else {
+			// TODO Get rid of null here
+			throw new SemanticException(source, null, "expected object");
+		}
+
+		return new SFieldAccessExpression(expression, field);
 	}
 
 	SExpression convert(IdentExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -49,6 +49,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNullExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
@@ -324,8 +325,8 @@ public record FunctionScope(
 		return new SThisExpression(currentClass.get());
 	}
 
-	SExpression convert(UnaryOperatorExpression expr) {
-		return null; // TODO Implement
+	SUnaryOperatorExpression convert(UnaryOperatorExpression expr) throws SemanticException {
+		return new SUnaryOperatorExpression(expr.operator(), convert(expr.expression()));
 	}
 
 	Optional<SClassType> typeToClassType(SExprType type) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -45,6 +45,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression
 import com.github.firmwehr.gentle.semantic.ast.expression.SIntegerValueExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
@@ -300,8 +301,8 @@ public record FunctionScope(
 		return new SMethodInvocationExpression(expression, method, arguments);
 	}
 
-	SExpression convert(NewArrayExpression expr) {
-		return null; // TODO Implement
+	SNewArrayExpression convert(NewArrayExpression expr) throws SemanticException {
+		return new SNewArrayExpression(convertNormal(expr.type()), convert(expr.size()));
 	}
 
 	SExpression convert(NewObjectExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -187,7 +187,8 @@ public record FunctionScope(
 
 		//noinspection ConstantConditions
 		if (type.isEmpty()) {
-			throw new SemanticException(source, expr.sourceSpan(), "expected array");
+			throw new SemanticException(source, expr.sourceSpan(), "invalid array access", expression.sourceSpan(),
+				"has type " + expression.type().format() + ", expected an array");
 		}
 
 		return new SArrayAccessExpression(expression, index, type.get(), expr.sourceSpan());
@@ -209,7 +210,8 @@ public record FunctionScope(
 
 		Optional<SClassType> classType = typeToClassType(expression.type());
 		if (classType.isEmpty()) {
-			throw new SemanticException(source, expr.sourceSpan(), "expected object");
+			throw new SemanticException(source, expr.sourceSpan(), "invalid field access", expression.sourceSpan(),
+				"has type " + expression.type().format() + ", expected an object");
 		}
 
 		SField field = classType.get().classDecl().fields().get(expr.name());
@@ -243,12 +245,12 @@ public record FunctionScope(
 
 	SMethodInvocationExpression convert(LocalMethodCallExpression expr) throws SemanticException {
 		if (currentClass.isEmpty()) {
-			throw new SemanticException(source, expr.name().sourceSpan(), "calling local method in static context");
+			throw new SemanticException(source, expr.sourceSpan(), "calling local method in static context");
 		}
 
 		SMethod method = currentClass.get().methods().get(expr.name());
 		if (method.isStatic()) {
-			throw new SemanticException(source, expr.name().sourceSpan(), "calling main method");
+			throw new SemanticException(source, expr.sourceSpan(), "calling main method");
 		}
 
 		List<SExpression> arguments = new ArrayList<>();
@@ -267,12 +269,13 @@ public record FunctionScope(
 
 		Optional<SClassType> classType = typeToClassType(expression.type());
 		if (classType.isEmpty()) {
-			throw new SemanticException(source, expr.sourceSpan(), "expected object");
+			throw new SemanticException(source, expr.sourceSpan(), "invalid method call", expression.sourceSpan(),
+				"has type " + expression.type().format() + ", expected an object");
 		}
 
 		SMethod method = classType.get().classDecl().methods().get(expr.name());
 		if (method.isStatic()) {
-			throw new SemanticException(source, expr.name().sourceSpan(), "calling main method");
+			throw new SemanticException(source, expr.sourceSpan(), "calling main method");
 		}
 
 		List<SExpression> arguments = new ArrayList<>();
@@ -289,6 +292,9 @@ public record FunctionScope(
 	}
 
 	SNewObjectExpression convert(NewObjectExpression expr) throws SemanticException {
+		if (expr.name().ident().equals("String")) {
+			throw new SemanticException(source, expr.sourceSpan(), "creating instance of built-in class");
+		}
 		return new SNewObjectExpression(classes.get(expr.name()), expr.sourceSpan());
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/FunctionScope.java
@@ -29,9 +29,7 @@ import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SField;
 import com.github.firmwehr.gentle.semantic.ast.SMethod;
-import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
-import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SBooleanValueExpression;
@@ -138,8 +136,8 @@ public record FunctionScope(
 			SExpression lhs = new SLocalVariableExpression(decl, statement.name().sourceSpan());
 			SExpression rhs = convert(statement.value().get().expression());
 			SourceSpan span = SourceSpan.from(lhs.sourceSpan(), statement.value().get().parenSourceSpan());
-			return Optional.of(new SExpressionStatement(
-				new SBinaryOperatorExpression(lhs, rhs, BinaryOperator.ASSIGN, decl.getType(), span)));
+			return Optional.of(
+				new SExpressionStatement(new SBinaryOperatorExpression(lhs, rhs, BinaryOperator.ASSIGN, span)));
 		} else {
 			return Optional.empty();
 		}
@@ -199,14 +197,7 @@ public record FunctionScope(
 		SExpression rhs = convert(expr.rhs());
 		SExpression lhs = convert(expr.lhs());
 
-		SExprType type = switch (expr.operator()) {
-			case ASSIGN -> rhs.type();
-			case LOGICAL_OR, LOGICAL_AND, EQUAL, NOT_EQUAL, LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL -> new SNormalType(
-				new SBooleanType());
-			case ADD, SUBTRACT, MULTIPLY, DIVIDE, MODULO -> new SNormalType(new SIntType());
-		};
-
-		return new SBinaryOperatorExpression(lhs, rhs, expr.operator(), type, expr.sourceSpan());
+		return new SBinaryOperatorExpression(lhs, rhs, expr.operator(), expr.sourceSpan());
 	}
 
 	SBooleanValueExpression convert(BooleanLiteralExpression expr) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/MethodScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/MethodScope.java
@@ -58,13 +58,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public record FunctionScope(
+public record MethodScope(
 	Source source,
 	Namespace<SClassDeclaration> classes,
 	Optional<SClassDeclaration> currentClass,
 	StackedNamespace<LocalVariableDeclaration> localVariables
 ) {
-	public static FunctionScope fromMethod(Source source, Namespace<SClassDeclaration> classes, SMethod method)
+	public static MethodScope fromMethod(Source source, Namespace<SClassDeclaration> classes, SMethod method)
 		throws SemanticException {
 
 		Optional<SClassDeclaration> currentClass =
@@ -75,7 +75,7 @@ public record FunctionScope(
 			localVariables.put(parameter.declaration(), parameter);
 		}
 
-		return new FunctionScope(source, classes, currentClass, localVariables);
+		return new MethodScope(source, classes, currentClass, localVariables);
 	}
 
 	public SBlock convert(Block block) throws SemanticException {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -42,6 +42,10 @@ public class Namespace<T> {
 		}
 	}
 
+	public boolean contains(String name) {
+		return content.containsKey(name);
+	}
+
 	public Set<T> getAll() {
 		return content.values().stream().map(Entry::value).collect(Collectors.toSet());
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -3,10 +3,10 @@ package com.github.firmwehr.gentle.semantic;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.source.Source;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class Namespace<T> {
@@ -37,12 +37,8 @@ public class Namespace<T> {
 		}
 	}
 
-	/**
-	 * @return the raw values in this namespace. This collection will always be distinct.
-	 */
-	public Collection<T> getAll() {
-		// The values might be recursive and fail to compute a usable hashcode
-		return content.values().stream().map(Entry::value).collect(Collectors.toList());
+	public Set<T> getAll() {
+		return content.values().stream().map(Entry::value).collect(Collectors.toSet());
 	}
 
 	private static record Entry<T>(

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -3,10 +3,10 @@ package com.github.firmwehr.gentle.semantic;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.source.Source;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class Namespace<T> {
@@ -37,8 +37,9 @@ public class Namespace<T> {
 		}
 	}
 
-	public Set<T> getAll() {
-		return content.values().stream().map(Entry::value).collect(Collectors.toSet());
+	public Collection<T> getAll() {
+		// Hashing recursive records is dangerous...
+		return content.values().stream().map(Entry::value).collect(Collectors.toList());
 	}
 
 	private static record Entry<T>(

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -9,6 +9,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * A map from string to element that rejects duplicate entries by throwing a {@link SemanticException}.
+ *
+ * @param <T> the type of the elements within
+ */
 public class Namespace<T> {
 	private final Source source;
 	private final Map<String, Entry<T>> content;

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -6,6 +6,8 @@ import com.github.firmwehr.gentle.source.Source;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Namespace<T> {
 	private final Source source;
@@ -33,6 +35,10 @@ public class Namespace<T> {
 		} else {
 			content.put(name.ident(), new Entry<>(name, t));
 		}
+	}
+
+	public Set<T> getAll() {
+		return content.values().stream().map(Entry::value).collect(Collectors.toSet());
 	}
 
 	private static record Entry<T>(

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Namespace.java
@@ -37,8 +37,11 @@ public class Namespace<T> {
 		}
 	}
 
+	/**
+	 * @return the raw values in this namespace. This collection will always be distinct.
+	 */
 	public Collection<T> getAll() {
-		// Hashing recursive records is dangerous...
+		// The values might be recursive and fail to compute a usable hashcode
 		return content.values().stream().map(Entry::value).collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -21,6 +21,7 @@ import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidyType;
 import com.github.firmwehr.gentle.source.Source;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,21 +74,23 @@ public class SemanticAnalyzer {
 			for (Field field : classDecl.fields()) {
 				Ident name = field.name();
 				SNormalType type = Util.normalTypeFromParserType(source, classes, field.type());
-				SField sField = new SField(sClassDecl, name, type);
+				SField sField = new SField(sClassDecl, name, type, field.type().sourceSpan());
 				sClassDecl.fields().put(name, sField);
 			}
 
 			for (Method method : classDecl.methods()) {
 				Ident name = method.name();
 				SVoidyType returnType = Util.voidyTypeFromParserType(source, classes, method.returnType());
+				SourceSpan returnTypeSpan = method.returnType().sourceSpan();
 
 				List<LocalVariableDeclaration> parameters = new ArrayList<>();
 				for (Parameter parameter : method.parameters()) {
 					SNormalType type = Util.normalTypeFromParserType(source, classes, parameter.type());
-					parameters.add(new LocalVariableDeclaration(type, parameter.name()));
+					SourceSpan typeSpan = parameter.type().sourceSpan();
+					parameters.add(new LocalVariableDeclaration(type, typeSpan, parameter.name()));
 				}
 
-				SMethod sMethod = SMethod.newMethod(sClassDecl, false, name, returnType, parameters);
+				SMethod sMethod = SMethod.newMethod(sClassDecl, false, name, returnType, returnTypeSpan, parameters);
 				sClassDecl.methods().put(name, sMethod);
 			}
 
@@ -95,10 +98,12 @@ public class SemanticAnalyzer {
 				Ident name = mainMethod.name();
 
 				SNormalType paramType = Util.normalTypeFromParserType(source, classes, mainMethod.parameter().type());
+				SourceSpan paramTypeSpan = mainMethod.parameter().type().sourceSpan();
 				Ident paramName = mainMethod.parameter().name();
-				LocalVariableDeclaration parameter = new LocalVariableDeclaration(paramType, paramName);
+				LocalVariableDeclaration parameter = new LocalVariableDeclaration(paramType, paramTypeSpan, paramName);
 
-				SMethod sMethod = SMethod.newMethod(sClassDecl, true, name, new SVoidType(), List.of(parameter));
+				SMethod sMethod = SMethod.newMethod(sClassDecl, true, name, new SVoidType(), mainMethod.voidSpan(),
+					List.of(parameter));
 				sClassDecl.methods().put(name, sMethod);
 			}
 		}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -14,6 +14,7 @@ import com.github.firmwehr.gentle.parser.ast.basictype.IntType;
 import com.github.firmwehr.gentle.parser.ast.basictype.VoidType;
 import com.github.firmwehr.gentle.semantic.analysis.AssignmentLValueVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.MainMethodLookupVisitor;
+import com.github.firmwehr.gentle.semantic.analysis.MethodReturnsVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.SideEffectVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.TypecheckVisitor;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
@@ -206,8 +207,19 @@ public class SemanticAnalyzer {
 		}
 	}
 
-	void checkReturnPaths(Namespace<SClassDeclaration> classes) {
-		// TODO Implement
+	/**
+	 * Checks that a method is either void or always returns.
+	 *
+	 * @param classes the classes to analyze
+	 *
+	 * @throws SemanticException if any path of a non void method does not return
+	 */
+	void checkReturnPaths(Namespace<SClassDeclaration> classes) throws SemanticException {
+		var visitor = new MethodReturnsVisitor(source);
+
+		for (SClassDeclaration declaration : classes.getAll()) {
+			visitor.visit(declaration);
+		}
 	}
 
 	/**

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -25,6 +25,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class SemanticAnalyzer {
 	private final Source source;
@@ -138,7 +139,7 @@ public class SemanticAnalyzer {
 	 * @throws SemanticException if any type error is detected.
 	 */
 	void checkTypes(Namespace<SClassDeclaration> classes) throws SemanticException {
-		Visitor<Void> visitor = new TypecheckVisitor(source);
+		Visitor<Optional<Void>> visitor = new TypecheckVisitor(source);
 
 		for (SClassDeclaration declaration : classes.getAll()) {
 			visitor.visit(declaration);
@@ -153,7 +154,7 @@ public class SemanticAnalyzer {
 	 * @throws SemanticException if any statement does not have a side effect
 	 */
 	void checkSideEffects(Namespace<SClassDeclaration> classes) throws SemanticException {
-		Visitor<Void> visitor = new SideEffectVisitor(source);
+		Visitor<Optional<Void>> visitor = new SideEffectVisitor(source);
 
 		for (SClassDeclaration declaration : classes.getAll()) {
 			visitor.visit(declaration);
@@ -168,7 +169,7 @@ public class SemanticAnalyzer {
 	 * @throws SemanticException if any assignment assigns to something else
 	 */
 	void checkAssignments(Namespace<SClassDeclaration> classes) throws SemanticException {
-		Visitor<Void> visitor = new AssignmentLValueVisitor(source);
+		Visitor<Optional<Void>> visitor = new AssignmentLValueVisitor(source);
 
 		for (SClassDeclaration declaration : classes.getAll()) {
 			visitor.visit(declaration);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -116,13 +116,13 @@ public class SemanticAnalyzer {
 
 			for (Method method : classDecl.methods()) {
 				SMethod sMethod = sClassDecl.methods().get(method.name());
-				FunctionScope scope = FunctionScope.fromMethod(source, classes, sMethod);
+				MethodScope scope = MethodScope.fromMethod(source, classes, sMethod);
 				sMethod.body().addAll(scope.convert(method.body()).statements());
 			}
 
 			for (MainMethod mainMethod : classDecl.mainMethods()) {
 				SMethod sMethod = sClassDecl.methods().get(mainMethod.name());
-				FunctionScope scope = FunctionScope.fromMethod(source, classes, sMethod);
+				MethodScope scope = MethodScope.fromMethod(source, classes, sMethod);
 				sMethod.body().addAll(scope.convert(mainMethod.body()).statements());
 			}
 		}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -12,6 +12,7 @@ import com.github.firmwehr.gentle.parser.ast.basictype.BooleanType;
 import com.github.firmwehr.gentle.parser.ast.basictype.IdentType;
 import com.github.firmwehr.gentle.parser.ast.basictype.IntType;
 import com.github.firmwehr.gentle.parser.ast.basictype.VoidType;
+import com.github.firmwehr.gentle.semantic.analysis.AssignmentLValueVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.MainMethodLookupVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.SideEffectVisitor;
 import com.github.firmwehr.gentle.semantic.analysis.TypecheckVisitor;
@@ -190,8 +191,19 @@ public class SemanticAnalyzer {
 		}
 	}
 
-	void checkAssignments(Namespace<SClassDeclaration> classes) {
-		// TODO Check if all assignments assign to an lvalue
+	/**
+	 * Checks that assignment expressions only assign to lvalues.
+	 *
+	 * @param classes the classes to analyze
+	 *
+	 * @throws SemanticException if any assignment assigns to something else
+	 */
+	void checkAssignments(Namespace<SClassDeclaration> classes) throws SemanticException {
+		Visitor<Void> visitor = new AssignmentLValueVisitor(source);
+
+		for (SClassDeclaration declaration : classes.getAll()) {
+			visitor.visit(declaration);
+		}
 	}
 
 	void checkReturnPaths(Namespace<SClassDeclaration> classes) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -35,7 +35,7 @@ public class SemanticAnalyzer {
 		this.program = program;
 	}
 
-	SProgram analyze() throws SemanticException {
+	public SProgram analyze() throws SemanticException {
 		Namespace<SClassDeclaration> classes = new Namespace<>(source);
 
 		addClasses(classes);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticAnalyzer.java
@@ -12,6 +12,7 @@ import com.github.firmwehr.gentle.parser.ast.basictype.BooleanType;
 import com.github.firmwehr.gentle.parser.ast.basictype.IdentType;
 import com.github.firmwehr.gentle.parser.ast.basictype.IntType;
 import com.github.firmwehr.gentle.parser.ast.basictype.VoidType;
+import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SField;
@@ -21,6 +22,21 @@ import com.github.firmwehr.gentle.semantic.ast.basictype.SBasicType;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
+import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrinlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
+import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidyType;
@@ -28,6 +44,7 @@ import com.github.firmwehr.gentle.source.Source;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class SemanticAnalyzer {
 	private final Source source;
@@ -154,13 +171,199 @@ public class SemanticAnalyzer {
 		}
 	}
 
-	void checkTypes(Namespace<SClassDeclaration> classes) {
+	void checkTypes(Namespace<SClassDeclaration> classes) throws SemanticException {
 		// TODO Implement
 		// TODO Don't forget the String type
+		Visitor<Void> visitor = new Visitor<>() {
+			SMethod currentMethod;
+
+			@Override
+			public Optional<Void> visit(SMethod method) throws SemanticException {
+				this.currentMethod = method;
+				return Visitor.super.visit(method);
+			}
+
+			@Override
+			public Optional<Void> visit(SIfStatement ifStatement) throws SemanticException {
+				assertIsBoolean(ifStatement.condition());
+
+				return Visitor.super.visit(ifStatement);
+			}
+
+			@Override
+			public Optional<Void> visit(SWhileStatement whileStatement) throws SemanticException {
+				assertIsBoolean(whileStatement.condition());
+				return Visitor.super.visit(whileStatement);
+			}
+
+			@Override
+			public Optional<Void> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
+				assertIsInt(arrayExpression.expression());
+				return Visitor.super.visit(arrayExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
+				assertIsInt(newArrayExpression.size());
+				return Visitor.super.visit(newArrayExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SUnaryOperatorExpression unaryOperatorExpression) throws SemanticException {
+				switch (unaryOperatorExpression.operator()) {
+					case LOGICAL_NOT, NEGATION -> assertIsBoolean(unaryOperatorExpression.expression());
+				}
+				return Visitor.super.visit(unaryOperatorExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
+				switch (binaryOperatorExpression.operator()) {
+					case ASSIGN -> {
+						SExprType rhsType = binaryOperatorExpression.rhs().type();
+						SExprType lhsType = binaryOperatorExpression.lhs().type();
+						if (!rhsType.isAssignableTo(lhsType)) {
+							throw new SemanticException(source, null, "Assignment of incompatible type");
+						}
+					}
+					case EQUAL, NOT_EQUAL -> {
+						SExprType rhsType = binaryOperatorExpression.rhs().type();
+						SExprType lhsType = binaryOperatorExpression.lhs().type();
+
+						if (!lhsType.isAssignableTo(rhsType) && !rhsType.isAssignableTo(lhsType)) {
+							throw new SemanticException(source, null, "Incompatible types in comparison");
+						}
+					}
+					case LOGICAL_OR, LOGICAL_AND -> {
+						assertIsBoolean(binaryOperatorExpression.lhs());
+						assertIsBoolean(binaryOperatorExpression.rhs());
+					}
+					case LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL, ADD, SUBTRACT, MULTIPLY, DIVIDE,
+						MODULO -> {
+						assertIsInt(binaryOperatorExpression.lhs());
+						assertIsInt(binaryOperatorExpression.rhs());
+					}
+				}
+				return Visitor.super.visit(binaryOperatorExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
+				assertIsInt(systemOutWriteExpression.argument());
+				return Visitor.super.visit(systemOutWriteExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
+				assertIsInt(systemOutPrinlnExpression.argument());
+				return Visitor.super.visit(systemOutPrinlnExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SMethodInvocationExpression methodInvocationExpression)
+				throws SemanticException {
+
+				SMethod target = methodInvocationExpression.method();
+				List<LocalVariableDeclaration> parameters = target.parameters();
+				List<SExpression> arguments = methodInvocationExpression.arguments();
+
+				if (parameters.size() != arguments.size()) {
+					throw new SemanticException(source, null, "Received wrong number of arguments");
+				}
+
+				for (int i = 0; i < parameters.size(); i++) {
+					if (!arguments.get(i).type().isAssignableTo(parameters.get(i).getType())) {
+						throw new SemanticException(source, null, "Mismatched types at index " + i);
+					}
+				}
+
+				return Visitor.super.visit(methodInvocationExpression);
+			}
+
+			@Override
+			public Optional<Void> visit(SReturnStatement returnStatement) throws SemanticException {
+				if (currentMethod == null) {
+					throw new IllegalStateException("Return outside of method");
+				}
+				Optional<SExpression> returnValue = returnStatement.returnValue();
+
+				if (returnValue.isEmpty()) {
+					if (returnStatement.returnValue().isPresent()) {
+						throw new SemanticException(source, null, "Void method must not return anything");
+					}
+					return Visitor.super.visit(returnStatement);
+				}
+
+				if (!returnValue.get().type().isAssignableTo(currentMethod.returnType().asExprType())) {
+					throw new SemanticException(source, null, "Not assignable to return type");
+				}
+
+				return Visitor.super.visit(returnStatement);
+			}
+
+			@Override
+			public Optional<Void> visit(SNewObjectExpression newObjectExpression) throws SemanticException {
+				Optional<SNormalType> normalType = newObjectExpression.type().asNormalType();
+
+				if (normalType.isPresent() && normalType.get().arrayLevel() == 0) {
+					if (normalType.get().basicType().asStringType().isPresent()) {
+						throw new SemanticException(source, null, "Can not create instances of String");
+					}
+				}
+
+				return Visitor.super.visit(newObjectExpression);
+			}
+
+			private void assertIsBoolean(SExpression expression) throws SemanticException {
+				Optional<SNormalType> normalType = expression.type().asNormalType();
+
+				if (normalType.isEmpty() || normalType.get().arrayLevel() != 0) {
+					throw new SemanticException(source, null, "Condition must be a boolean");
+				}
+
+				if (normalType.get().basicType().asBooleanType().isEmpty()) {
+					throw new SemanticException(source, null, "Condition must be a boolean");
+				}
+			}
+
+			private void assertIsInt(SExpression expression) throws SemanticException {
+				Optional<SNormalType> normalType = expression.type().asNormalType();
+
+				if (normalType.isEmpty() || normalType.get().arrayLevel() != 0) {
+					throw new SemanticException(source, null, "Expression must be an integer");
+				}
+
+				if (normalType.get().basicType().asIntType().isEmpty()) {
+					throw new SemanticException(source, null, "Expression must be an integer");
+				}
+			}
+
+		};
+
+		for (SClassDeclaration declaration : classes.getAll()) {
+			visitor.visit(declaration);
+		}
 	}
 
-	void checkSideEffects(Namespace<SClassDeclaration> classes) {
+	void checkSideEffects(Namespace<SClassDeclaration> classes) throws SemanticException {
 		// TODO Check if all ExpressionStatements have side effects
+
+		Visitor<Void> visitor = new Visitor<>() {
+			@Override
+			public Optional<Void> visit(SExpressionStatement expressionStatement) throws SemanticException {
+				SExpression expression = expressionStatement.expression();
+				return switch (expression) {
+					case SMethodInvocationExpression ignored -> Optional.empty();
+					case SBinaryOperatorExpression op && op.operator() == BinaryOperator.ASSIGN -> Optional.empty();
+					default -> throw new SemanticException(source, null,
+						"Expression statement must habe side " + "effects");
+				};
+			}
+		};
+
+		for (SClassDeclaration declaration : classes.getAll()) {
+			visitor.visit(declaration);
+		}
 	}
 
 	void checkAssignments(Namespace<SClassDeclaration> classes) {
@@ -171,9 +374,57 @@ public class SemanticAnalyzer {
 		// TODO Implement
 	}
 
-	SMethod findMainMethod(Namespace<SClassDeclaration> classes) {
+	SMethod findMainMethod(Namespace<SClassDeclaration> classes) throws SemanticException {
 		// TODO Implement
 		// TODO Check main method semantics
-		return null;
+
+		Visitor<SMethod> visitor = new Visitor<>() {
+			private SMethod foundMainMethod;
+			private LocalVariableDeclaration mainMethodParameter;
+
+			@Override
+			public Optional<SMethod> visit(SMethod method) throws SemanticException {
+				if (!method.isStatic()) {
+					return Optional.empty();
+				}
+				if (this.foundMainMethod != null) {
+					throw new SemanticException(source, null, "Found second main method!");
+				}
+				if (!method.name().ident().equals("main")) {
+					throw new SemanticException(source, null, "Only 'main' is allowed for static method names");
+				}
+				if (method.parameters().size() != 1) {
+					throw new IllegalArgumentException("The main method must have exactly one parameter");
+				}
+				LocalVariableDeclaration parameter = method.parameters().get(0);
+
+				if (parameter.getType().arrayLevel() != 1) {
+					throw new SemanticException(source, null, "The main method must have a String[] parameter");
+				}
+				if (parameter.getType().basicType().asStringType().isEmpty()) {
+					throw new SemanticException(source, null, "The main method must have a String[] parameter");
+				}
+
+				this.foundMainMethod = method;
+				this.mainMethodParameter = parameter;
+
+				Visitor.super.visit(method);
+				return Optional.of(method);
+			}
+
+			@Override
+			public Optional<SMethod> visit(SLocalVariableExpression localVariableExpression) throws SemanticException {
+				if (localVariableExpression.localVariable() == mainMethodParameter) {
+					throw new SemanticException(source, null, "Usage of main method parameter is forbidden");
+				}
+				return Visitor.super.visit(localVariableExpression);
+			}
+		};
+
+		Optional<SMethod> main = Optional.empty();
+		for (SClassDeclaration declaration : classes.getAll()) {
+			main = visitor.visit(declaration);
+		}
+		return main.orElseThrow(() -> new SemanticException(source, null, "Did not find a main method :/"));
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
@@ -6,6 +6,7 @@ import com.github.firmwehr.gentle.util.Pair;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class SemanticException extends Exception {
 	private final Source source;
@@ -56,9 +57,9 @@ public class SemanticException extends Exception {
 
 		description.ifPresent(s -> builder.append("\n").append(s));
 
-		for (Pair<SourceSpan, String> annotation : annotations) {
-			builder.append("\n").append(source.formatMessageAt(annotation.first(), annotation.second()));
-		}
+		builder.append(annotations.stream()
+			.map(annotation -> "\n" + source.formatMessageAt(annotation.first(), annotation.second()))
+			.collect(Collectors.joining("\n")));
 
 		return builder.toString();
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
@@ -2,45 +2,65 @@ package com.github.firmwehr.gentle.semantic;
 
 import com.github.firmwehr.gentle.source.Source;
 import com.github.firmwehr.gentle.source.SourceSpan;
+import com.github.firmwehr.gentle.util.Pair;
 
+import java.util.List;
 import java.util.Optional;
 
 public class SemanticException extends Exception {
 	private final Source source;
-	private final SourceSpan errorLocation;
-	private final String errorDescription;
-	private final Optional<SourceSpan> referenceLocation;
-	private final Optional<String> referenceDescription;
+	private final Optional<String> description;
+	private final List<Pair<SourceSpan, String>> annotations;
 
-	public SemanticException(Source source, SourceSpan errorLocation, String errorDescription) {
+	public SemanticException(Source source, String description) {
 		this.source = source;
-		this.errorLocation = errorLocation;
-		this.errorDescription = errorDescription;
-		referenceLocation = Optional.empty();
-		referenceDescription = Optional.empty();
+		this.description = Optional.of(description);
+		this.annotations = List.of();
+	}
+
+	public SemanticException(Source source, List<Pair<SourceSpan, String>> annotations) {
+		this.source = source;
+		this.description = Optional.empty();
+		this.annotations = annotations;
+	}
+
+	public SemanticException(Source source, SourceSpan location, String description) {
+		this(source, List.of(new Pair<>(location, description)));
 	}
 
 	public SemanticException(
-		Source source,
-		SourceSpan errorLocation,
-		String errorDescription,
-		SourceSpan referenceLocation,
-		String referenceDescription
+		Source source, SourceSpan location1, String description1, SourceSpan location2, String description2
 	) {
-		this.source = source;
-		this.errorLocation = errorLocation;
-		this.errorDescription = errorDescription;
-		this.referenceLocation = Optional.of(referenceLocation);
-		this.referenceDescription = Optional.of(referenceDescription);
+		this(source, List.of(new Pair<>(location1, description1), new Pair<>(location2, description2)));
+	}
+
+
+	public SemanticException(
+		Source source,
+		SourceSpan location1,
+		String description1,
+		SourceSpan location2,
+		String description2,
+		SourceSpan location3,
+		String description3
+	) {
+		this(source, List.of(new Pair<>(location1, description1), new Pair<>(location2, description2),
+			new Pair<>(location3, description3)));
 	}
 
 	@Override
 	public String getMessage() {
-		if (referenceLocation.isPresent() && referenceDescription.isPresent()) {
-			return source.formatErrorWithReferenceAt("Semantic error", errorLocation.startOffset(), errorDescription,
-				referenceLocation.get().startOffset(), referenceDescription.get());
-		} else {
-			return source.formatErrorAt("Semantic error", errorLocation.startOffset(), errorDescription);
+		StringBuilder builder = new StringBuilder();
+
+		builder.append("Semantic error");
+
+		description.ifPresent(s -> builder.append("\n").append(s));
+
+		for (Pair<SourceSpan, String> annotation : annotations) {
+			builder.append("\n")
+				.append(source.formatMessagePointingTo(annotation.first().startOffset(), annotation.second()));
 		}
+
+		return builder.toString();
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/SemanticException.java
@@ -57,8 +57,7 @@ public class SemanticException extends Exception {
 		description.ifPresent(s -> builder.append("\n").append(s));
 
 		for (Pair<SourceSpan, String> annotation : annotations) {
-			builder.append("\n")
-				.append(source.formatMessagePointingTo(annotation.first().startOffset(), annotation.second()));
+			builder.append("\n").append(source.formatMessageAt(annotation.first(), annotation.second()));
 		}
 
 		return builder.toString();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/StackedNamespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/StackedNamespace.java
@@ -71,6 +71,13 @@ public class StackedNamespace<T> {
 		}
 	}
 
+	public boolean contains(String name) {
+		if (scopes.isEmpty()) {
+			return false;
+		}
+		return scopes.peekFirst().get(name) != null;
+	}
+
 	private record Entry<T>(
 		Ident ident,
 		T value

--- a/src/main/java/com/github/firmwehr/gentle/semantic/StackedNamespace.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/StackedNamespace.java
@@ -9,6 +9,16 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
 
+/**
+ * A namespace that maps strings to some value. This differs from a normal map, as it allows the user to {@link
+ * #enterScope() enter} and {@link #leaveScope() leave} scopes. When you enter a new scope, all your existing mappings
+ * are kept. Wenn you leave a scope, all mappings you added using {@link #put(Ident, Object)} while in that scope will
+ * be removed.
+ * <p>
+ * This implementation still allows for fast lookup by using a persistent map.
+ *
+ * @param <T> the type of the elements contained within
+ */
 public class StackedNamespace<T> {
 
 	private final Source source;

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Util.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Util.java
@@ -1,0 +1,50 @@
+package com.github.firmwehr.gentle.semantic;
+
+import com.github.firmwehr.gentle.parser.ast.Type;
+import com.github.firmwehr.gentle.parser.ast.basictype.BooleanType;
+import com.github.firmwehr.gentle.parser.ast.basictype.IdentType;
+import com.github.firmwehr.gentle.parser.ast.basictype.IntType;
+import com.github.firmwehr.gentle.parser.ast.basictype.VoidType;
+import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SBasicType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
+import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+import com.github.firmwehr.gentle.semantic.ast.type.SVoidyType;
+import com.github.firmwehr.gentle.source.Source;
+
+public final class Util {
+	private Util() {
+	}
+
+	public static SNormalType normalTypeFromParserType(
+		Source source, Namespace<SClassDeclaration> classes, Type type
+	) throws SemanticException {
+		SBasicType basicType = switch (type.basicType()) {
+			case BooleanType t -> new SBooleanType();
+			case IdentType t -> new SClassType(classes.get(t.name()));
+			case IntType t -> new SIntType();
+			case VoidType t -> throw new SemanticException(source, t.sourceSpan(), "void not allowed here");
+		};
+
+		return new SNormalType(basicType, type.arrayLevel());
+	}
+
+	public static SVoidyType voidyTypeFromParserType(
+		Source source, Namespace<SClassDeclaration> classes, Type type
+	) throws SemanticException {
+		return switch (type.basicType()) {
+			case BooleanType t -> new SNormalType(new SBooleanType(), type.arrayLevel());
+			case IdentType t -> new SNormalType(new SClassType(classes.get(t.name())), type.arrayLevel());
+			case IntType t -> new SNormalType(new SIntType(), type.arrayLevel());
+			case VoidType t -> {
+				if (type.arrayLevel() > 0) {
+					throw new SemanticException(source, t.sourceSpan(), "void not allowed here");
+				}
+				yield new SVoidType();
+			}
+		};
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Util.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Util.java
@@ -24,7 +24,7 @@ public final class Util {
 		Source source, Namespace<SClassDeclaration> classes, Type type
 	) throws SemanticException {
 		SBasicType basicType = switch (type.basicType()) {
-			case BooleanType t -> new SBooleanType();
+			case BooleanType ignored -> new SBooleanType();
 			case IdentType t -> {
 				if (t.name().ident().equals("String")) {
 					yield new SStringType();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
@@ -16,7 +16,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNullExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SSystemInReadExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutFlushExpression;
-import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrinlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrintlnExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
@@ -89,8 +89,8 @@ public interface Visitor<T> {
 		return Optional.empty();
 	}
 
-	default Optional<T> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
-		systemOutPrinlnExpression.argument().accept(this);
+	default Optional<T> visit(SSystemOutPrintlnExpression systemOutPrintlnExpression) throws SemanticException {
+		systemOutPrintlnExpression.argument().accept(this);
 		return Optional.empty();
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
@@ -1,0 +1,169 @@
+package com.github.firmwehr.gentle.semantic;
+
+import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
+import com.github.firmwehr.gentle.semantic.ast.SField;
+import com.github.firmwehr.gentle.semantic.ast.SMethod;
+import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBooleanValueExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SIntegerValueExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNullExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemInReadExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutFlushExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrinlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SThisExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
+import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
+
+import java.util.Optional;
+
+public interface Visitor<T> {
+
+	//<editor-fold desc="Expressions">
+	default Optional<T> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
+		arrayExpression.expression().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
+		binaryOperatorExpression.lhs().accept(this);
+		binaryOperatorExpression.rhs().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SBooleanValueExpression booleanValueExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SFieldAccessExpression fieldAccessExpression) throws SemanticException {
+		fieldAccessExpression.expression().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SIntegerValueExpression integerValueExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SLocalVariableExpression localVariableExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SMethodInvocationExpression methodInvocationExpression) throws SemanticException {
+		methodInvocationExpression.expression().accept(this);
+		for (SExpression argument : methodInvocationExpression.arguments()) {
+			argument.accept(this);
+		}
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
+		newArrayExpression.size().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SNewObjectExpression newObjectExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SNullExpression nullExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SSystemInReadExpression systemInReadExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SSystemOutFlushExpression systemOutFlushExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
+		systemOutPrinlnExpression.argument().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
+		systemOutWriteExpression.argument().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SThisExpression thisExpression) throws SemanticException {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SUnaryOperatorExpression unaryOperatorExpression) throws SemanticException {
+		unaryOperatorExpression.expression().accept(this);
+		return Optional.empty();
+	}
+	//</editor-fold>
+
+	//<editor-fold desc="Statements">
+	default Optional<T> visit(SBlock block) throws SemanticException {
+		for (SStatement sStatement : block.statements()) {
+			sStatement.accept(this);
+		}
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SExpressionStatement expressionStatement) throws SemanticException {
+		expressionStatement.expression().accept(this);
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SIfStatement ifStatement) throws SemanticException {
+		ifStatement.condition().accept(this);
+		ifStatement.body().accept(this);
+		if (ifStatement.elseBody().isPresent()) {
+			ifStatement.elseBody().get().accept(this);
+		}
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SReturnStatement returnStatement) throws SemanticException {
+		if (returnStatement.returnValue().isPresent()) {
+			returnStatement.returnValue().get().accept(this);
+		}
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SWhileStatement whileStatement) throws SemanticException {
+		whileStatement.condition().accept(this);
+		whileStatement.body().accept(this);
+		return Optional.empty();
+	}
+	//</editor-fold>
+
+	default Optional<T> visit(SMethod method) throws SemanticException {
+		for (SStatement sStatement : method.body()) {
+			sStatement.accept(this);
+		}
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SField field) {
+		return Optional.empty();
+	}
+
+	default Optional<T> visit(SClassDeclaration classDeclaration) throws SemanticException {
+		for (SField sField : classDeclaration.fields().getAll()) {
+			visit(sField);
+		}
+		for (SMethod sMethod : classDeclaration.methods().getAll()) {
+			visit(sMethod);
+		}
+
+		return Optional.empty();
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/Visitor.java
@@ -27,136 +27,136 @@ import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
 
-import java.util.Optional;
-
 public interface Visitor<T> {
 
+	T defaultReturnValue();
+
 	//<editor-fold desc="Expressions">
-	default Optional<T> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
+	default T visit(SArrayAccessExpression arrayExpression) throws SemanticException {
 		arrayExpression.expression().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
+	default T visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
 		binaryOperatorExpression.lhs().accept(this);
 		binaryOperatorExpression.rhs().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SBooleanValueExpression booleanValueExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SBooleanValueExpression booleanValueExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SFieldAccessExpression fieldAccessExpression) throws SemanticException {
+	default T visit(SFieldAccessExpression fieldAccessExpression) throws SemanticException {
 		fieldAccessExpression.expression().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SIntegerValueExpression integerValueExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SIntegerValueExpression integerValueExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SLocalVariableExpression localVariableExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SLocalVariableExpression localVariableExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SMethodInvocationExpression methodInvocationExpression) throws SemanticException {
+	default T visit(SMethodInvocationExpression methodInvocationExpression) throws SemanticException {
 		methodInvocationExpression.expression().accept(this);
 		for (SExpression argument : methodInvocationExpression.arguments()) {
 			argument.accept(this);
 		}
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
+	default T visit(SNewArrayExpression newArrayExpression) throws SemanticException {
 		newArrayExpression.size().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SNewObjectExpression newObjectExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SNewObjectExpression newObjectExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SNullExpression nullExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SNullExpression nullExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SSystemInReadExpression systemInReadExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SSystemInReadExpression systemInReadExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SSystemOutFlushExpression systemOutFlushExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SSystemOutFlushExpression systemOutFlushExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SSystemOutPrintlnExpression systemOutPrintlnExpression) throws SemanticException {
+	default T visit(SSystemOutPrintlnExpression systemOutPrintlnExpression) throws SemanticException {
 		systemOutPrintlnExpression.argument().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
+	default T visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
 		systemOutWriteExpression.argument().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SThisExpression thisExpression) throws SemanticException {
-		return Optional.empty();
+	default T visit(SThisExpression thisExpression) throws SemanticException {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SUnaryOperatorExpression unaryOperatorExpression) throws SemanticException {
+	default T visit(SUnaryOperatorExpression unaryOperatorExpression) throws SemanticException {
 		unaryOperatorExpression.expression().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 	//</editor-fold>
 
 	//<editor-fold desc="Statements">
-	default Optional<T> visit(SBlock block) throws SemanticException {
+	default T visit(SBlock block) throws SemanticException {
 		for (SStatement sStatement : block.statements()) {
 			sStatement.accept(this);
 		}
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SExpressionStatement expressionStatement) throws SemanticException {
+	default T visit(SExpressionStatement expressionStatement) throws SemanticException {
 		expressionStatement.expression().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SIfStatement ifStatement) throws SemanticException {
+	default T visit(SIfStatement ifStatement) throws SemanticException {
 		ifStatement.condition().accept(this);
 		ifStatement.body().accept(this);
 		if (ifStatement.elseBody().isPresent()) {
 			ifStatement.elseBody().get().accept(this);
 		}
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SReturnStatement returnStatement) throws SemanticException {
+	default T visit(SReturnStatement returnStatement) throws SemanticException {
 		if (returnStatement.returnValue().isPresent()) {
 			returnStatement.returnValue().get().accept(this);
 		}
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SWhileStatement whileStatement) throws SemanticException {
+	default T visit(SWhileStatement whileStatement) throws SemanticException {
 		whileStatement.condition().accept(this);
 		whileStatement.body().accept(this);
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 	//</editor-fold>
 
-	default Optional<T> visit(SMethod method) throws SemanticException {
+	default T visit(SMethod method) throws SemanticException {
 		for (SStatement sStatement : method.body()) {
 			sStatement.accept(this);
 		}
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SField field) {
-		return Optional.empty();
+	default T visit(SField field) {
+		return defaultReturnValue();
 	}
 
-	default Optional<T> visit(SClassDeclaration classDeclaration) throws SemanticException {
+	default T visit(SClassDeclaration classDeclaration) throws SemanticException {
 		for (SField sField : classDeclaration.fields().getAll()) {
 			visit(sField);
 		}
@@ -164,6 +164,6 @@ public interface Visitor<T> {
 			visit(sMethod);
 		}
 
-		return Optional.empty();
+		return defaultReturnValue();
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
@@ -1,0 +1,49 @@
+package com.github.firmwehr.gentle.semantic.analysis;
+
+import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SFieldAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.source.Source;
+
+import java.util.Optional;
+
+/**
+ * Ensures all assignment expressions assign to lvalues. In Java this is
+ * <ul>
+ *     <li>A variable or field access, i.e. {@code foo = 20}</li>
+ *     <li>A computed member access, i.e. {@code bar.foo = 20}</li>
+ *     <li>An array access, i.e. {@code foo[20] = 20}</li>
+ * </ul>
+ */
+@SuppressWarnings("ClassCanBeRecord")
+public class AssignmentLValueVisitor implements Visitor<Void> {
+	private final Source source;
+
+	public AssignmentLValueVisitor(Source source) {
+		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
+		if (binaryOperatorExpression.operator() != BinaryOperator.ASSIGN) {
+			return Visitor.super.visit(binaryOperatorExpression);
+		}
+
+		SExpression lhs = binaryOperatorExpression.lhs();
+
+		boolean isVariableOrFieldAccess =
+			lhs instanceof SLocalVariableExpression || lhs instanceof SFieldAccessExpression;
+		boolean isArrayAccess = lhs instanceof SArrayAccessExpression;
+
+		if (!isVariableOrFieldAccess && !isArrayAccess) {
+			throw new SemanticException(source, null, "You can only assign to lvalues");
+		}
+
+		return Visitor.super.visit(binaryOperatorExpression);
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
@@ -36,11 +36,11 @@ public class AssignmentLValueVisitor implements Visitor<Void> {
 
 		SExpression lhs = binaryOperatorExpression.lhs();
 
-		boolean isVariableOrFieldAccess =
-			lhs instanceof SLocalVariableExpression || lhs instanceof SFieldAccessExpression;
+		boolean isVariableAccess = lhs instanceof SLocalVariableExpression;
+		boolean isFieldAccess = lhs instanceof SFieldAccessExpression;
 		boolean isArrayAccess = lhs instanceof SArrayAccessExpression;
 
-		if (!isVariableOrFieldAccess && !isArrayAccess) {
+		if (!(isVariableAccess || isFieldAccess || isArrayAccess)) {
 			throw new SemanticException(source, null, "You can only assign to lvalues");
 		}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
@@ -20,7 +20,6 @@ import java.util.Optional;
  *     <li>An array access, i.e. {@code foo[20] = 20}</li>
  * </ul>
  */
-@SuppressWarnings("ClassCanBeRecord")
 public class AssignmentLValueVisitor implements Visitor<Void> {
 	private final Source source;
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
@@ -20,11 +20,16 @@ import java.util.Optional;
  *     <li>An array access, i.e. {@code foo[20] = 20}</li>
  * </ul>
  */
-public class AssignmentLValueVisitor implements Visitor<Void> {
+public class AssignmentLValueVisitor implements Visitor<Optional<Void>> {
 	private final Source source;
 
 	public AssignmentLValueVisitor(Source source) {
 		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> defaultReturnValue() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/AssignmentLValueVisitor.java
@@ -41,7 +41,8 @@ public class AssignmentLValueVisitor implements Visitor<Void> {
 		boolean isArrayAccess = lhs instanceof SArrayAccessExpression;
 
 		if (!(isVariableAccess || isFieldAccess || isArrayAccess)) {
-			throw new SemanticException(source, null, "You can only assign to lvalues");
+			throw new SemanticException(source, binaryOperatorExpression.sourceSpan(), "invalid assignment",
+				lhs.sourceSpan(), "not an lvalue");
 		}
 
 		return Visitor.super.visit(binaryOperatorExpression);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -48,6 +48,8 @@ public class MainMethodLookupVisitor implements Visitor<Optional<Void>> {
 			throw new SemanticException(source, method.name().sourceSpan(), "main method must be named 'main'");
 		}
 
+		// These two cases are already prevented by the grammar and parser, so if these checks are not successful,
+		// something went wrong in our code.
 		if (!(method.returnType() instanceof SVoidType)) {
 			throw new IllegalArgumentException("The main method must have a void return type");
 		}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -36,10 +36,11 @@ public class MainMethodLookupVisitor implements Visitor<Void> {
 			return Optional.empty();
 		}
 		if (this.foundMainMethod.isPresent()) {
-			throw new SemanticException(source, null, "Found second main method!");
+			throw new SemanticException(source, method.name().sourceSpan(), "duplicate main method",
+				foundMainMethod.get().name().sourceSpan(), "already defined here");
 		}
 		if (!method.name().ident().equals("main")) {
-			throw new SemanticException(source, null, "Only 'main' is allowed for static method names");
+			throw new SemanticException(source, method.name().sourceSpan(), "main method must be named 'main'");
 		}
 
 		if (!(method.returnType() instanceof SVoidType)) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -52,11 +52,8 @@ public class MainMethodLookupVisitor implements Visitor<Void> {
 
 		LocalVariableDeclaration parameter = method.parameters().get(0);
 
-		if (parameter.getType().arrayLevel() != 1) {
-			throw new SemanticException(source, null, "The main method must have a String[] parameter");
-		}
-		if (parameter.getType().basicType().asStringType().isEmpty()) {
-			throw new SemanticException(source, null, "The main method must have a String[] parameter");
+		if (parameter.getType().arrayLevel() != 1 || parameter.getType().basicType().asStringType().isEmpty()) {
+			throw new SemanticException(source, parameter.getTypeSpan(), "expected String[]");
 		}
 
 		this.foundMainMethod = Optional.of(method);
@@ -70,13 +67,14 @@ public class MainMethodLookupVisitor implements Visitor<Void> {
 		LocalVariableDeclaration localVariable = localVariableExpression.localVariable();
 
 		if (mainMethodParameter.map(it -> it == localVariable).orElse(false)) {
-			throw new SemanticException(source, null, "Usage of main method parameter is forbidden");
+			throw new SemanticException(source, localVariableExpression.sourceSpan(),
+				"illegal use of main method parameter", localVariable.getDeclaration().sourceSpan(), "declared here");
 		}
 
 		return Visitor.super.visit(localVariableExpression);
 	}
 
 	public SMethod getFoundMainMethod() throws SemanticException {
-		return foundMainMethod.orElseThrow(() -> new SemanticException(source, null, "Did not find a main method :/"));
+		return foundMainMethod.orElseThrow(() -> new SemanticException(source, "no main method found"));
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -1,0 +1,79 @@
+package com.github.firmwehr.gentle.semantic.analysis;
+
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
+import com.github.firmwehr.gentle.semantic.ast.SMethod;
+import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.source.Source;
+
+import java.util.Optional;
+
+/**
+ * Finds the main method, ensures it is globally unique and exists and:
+ * <ul>
+ *     <li>Is named main</li>
+ *     <li>Has a single parameter of type String[]</li>
+ *     <li>Has a void return type</li>
+ *     <li>Is static</li>
+ *     <li>The parameter is never used in the method</li>
+ * </ul>
+ */
+public class MainMethodLookupVisitor implements Visitor<Void> {
+	private final Source source;
+
+	private Optional<SMethod> foundMainMethod = Optional.empty();
+	private Optional<LocalVariableDeclaration> mainMethodParameter = Optional.empty();
+
+	public MainMethodLookupVisitor(Source source) {
+		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> visit(SMethod method) throws SemanticException {
+		if (!method.isStatic()) {
+			return Optional.empty();
+		}
+		if (this.foundMainMethod.isPresent()) {
+			throw new SemanticException(source, null, "Found second main method!");
+		}
+		if (!method.name().ident().equals("main")) {
+			throw new SemanticException(source, null, "Only 'main' is allowed for static method names");
+		}
+		if (method.returnType().asExprType().asVoidType().isEmpty()) {
+			throw new SemanticException(source, null, "The main method must have a void return type");
+		}
+
+		if (method.parameters().size() != 1) {
+			throw new IllegalArgumentException("The main method must have exactly one parameter");
+		}
+		LocalVariableDeclaration parameter = method.parameters().get(0);
+
+		if (parameter.getType().arrayLevel() != 1) {
+			throw new SemanticException(source, null, "The main method must have a String[] parameter");
+		}
+		if (parameter.getType().basicType().asStringType().isEmpty()) {
+			throw new SemanticException(source, null, "The main method must have a String[] parameter");
+		}
+
+		this.foundMainMethod = Optional.of(method);
+		this.mainMethodParameter = Optional.of(parameter);
+
+		return Visitor.super.visit(method);
+	}
+
+	@Override
+	public Optional<Void> visit(SLocalVariableExpression localVariableExpression) throws SemanticException {
+		LocalVariableDeclaration localVariable = localVariableExpression.localVariable();
+
+		if (mainMethodParameter.map(it -> it == localVariable).orElse(false)) {
+			throw new SemanticException(source, null, "Usage of main method parameter is forbidden");
+		}
+
+		return Visitor.super.visit(localVariableExpression);
+	}
+
+	public SMethod getFoundMainMethod() throws SemanticException {
+		return foundMainMethod.orElseThrow(() -> new SemanticException(source, null, "Did not find a main method :/"));
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  *     <li>The parameter is never used in the method</li>
  * </ul>
  */
-public class MainMethodLookupVisitor implements Visitor<Void> {
+public class MainMethodLookupVisitor implements Visitor<Optional<Void>> {
 	private final Source source;
 
 	private Optional<SMethod> foundMainMethod = Optional.empty();
@@ -28,6 +28,11 @@ public class MainMethodLookupVisitor implements Visitor<Void> {
 
 	public MainMethodLookupVisitor(Source source) {
 		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> defaultReturnValue() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -57,8 +57,8 @@ public class MainMethodLookupVisitor implements Visitor<Optional<Void>> {
 
 		LocalVariableDeclaration parameter = method.parameters().get(0);
 
-		if (parameter.getType().arrayLevel() != 1 || parameter.getType().basicType().asStringType().isEmpty()) {
-			throw new SemanticException(source, parameter.getTypeSpan(), "expected String[]");
+		if (parameter.type().arrayLevel() != 1 || parameter.type().basicType().asStringType().isEmpty()) {
+			throw new SemanticException(source, parameter.typeSpan(), "expected String[]");
 		}
 
 		this.foundMainMethod = Optional.of(method);
@@ -73,7 +73,7 @@ public class MainMethodLookupVisitor implements Visitor<Optional<Void>> {
 
 		if (mainMethodParameter.map(it -> it == localVariable).orElse(false)) {
 			throw new SemanticException(source, localVariableExpression.sourceSpan(),
-				"illegal use of main method parameter", localVariable.getDeclaration().sourceSpan(), "declared here");
+				"illegal use of main method parameter", localVariable.declaration().sourceSpan(), "declared here");
 		}
 
 		return Visitor.super.visit(localVariableExpression);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MainMethodLookupVisitor.java
@@ -5,6 +5,7 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.SMethod;
 import com.github.firmwehr.gentle.semantic.ast.expression.SLocalVariableExpression;
+import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.source.Source;
 
 import java.util.Optional;
@@ -40,13 +41,14 @@ public class MainMethodLookupVisitor implements Visitor<Void> {
 		if (!method.name().ident().equals("main")) {
 			throw new SemanticException(source, null, "Only 'main' is allowed for static method names");
 		}
-		if (method.returnType().asExprType().asVoidType().isEmpty()) {
-			throw new SemanticException(source, null, "The main method must have a void return type");
-		}
 
+		if (!(method.returnType() instanceof SVoidType)) {
+			throw new IllegalArgumentException("The main method must have a void return type");
+		}
 		if (method.parameters().size() != 1) {
 			throw new IllegalArgumentException("The main method must have exactly one parameter");
 		}
+
 		LocalVariableDeclaration parameter = method.parameters().get(0);
 
 		if (parameter.getType().arrayLevel() != 1) {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
@@ -45,7 +45,7 @@ public class MethodReturnsVisitor implements Visitor<MethodReturnsVisitor.Return
 			}
 		}
 
-		throw new SemanticException(source, null, "Found path not leading to return");
+		throw new SemanticException(source, method.name().sourceSpan(), "missing return statement");
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
@@ -16,9 +16,9 @@ import java.util.Optional;
  * <br>
  * This is implemented using a simple algorithm:
  * <ol>
- *     <li>For every statement in a method or block, check whether it always returns. If it always returns, the
- *     method always returns as any potentially following code is unreachable.</li>
- *     <li>If we reached the end of the method body the method doesn't always return and we throw an exception.</li>>
+ *     <li>If any statement in a method or block always returns, that method or block always returns. All following
+ *     statements are unreachable.</li>
+ *     <li>Otherwise, the method or block doesn't always return.</li>
  * </ol>
  * Additionally, the {@link SReturnStatement} is marked to always return and acts as the starting point.
  */

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
@@ -1,0 +1,82 @@
+package com.github.firmwehr.gentle.semantic.analysis;
+
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.SMethod;
+import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
+import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SStatement;
+import com.github.firmwehr.gentle.source.Source;
+
+import java.util.Optional;
+
+/**
+ * Ensures every method is either void or every path leads to a return statement.
+ * <br>
+ * This is implemented using a simple algorithm:
+ * <ol>
+ *     <li>For every statement in a method or block, check whether it always returns. If it always returns, the
+ *     method always returns as any potentially following code is unreachable.</li>
+ *     <li>If we reached the end of the method body the method doesn't always return and we throw an exception.</li>>
+ * </ol>
+ * Additionally, the {@link SReturnStatement} is marked to always return and acts as the starting point.
+ */
+@SuppressWarnings("ClassCanBeRecord")
+public class MethodReturnsVisitor implements Visitor<MethodReturnsVisitor.Returns> {
+	private final Source source;
+
+	public MethodReturnsVisitor(Source source) {
+		this.source = source;
+	}
+
+	@Override
+	public Optional<Returns> visit(SMethod method) throws SemanticException {
+		// We do not need to check void methods. If they have a return statement it is verified by type
+		// checking and any path not explicitly returning just implicitly ends.
+		if (method.returnType().asExprType().asVoidType().isPresent()) {
+			return Optional.of(Returns.YES);
+		}
+
+		for (SStatement statement : method.body()) {
+			// This statement always returns so the rest is unreachable code, and we can bail out.
+			if (statement.accept(this).isPresent()) {
+				return Optional.of(Returns.YES);
+			}
+		}
+
+		throw new SemanticException(source, null, "Found path not leading to return");
+	}
+
+	@Override
+	public Optional<Returns> visit(SIfStatement ifStatement) throws SemanticException {
+		if (ifStatement.body().accept(this).isEmpty()) {
+			return Optional.empty();
+		}
+		// The body always returns, but we have no else => This might not return if the condition isn't always true
+		if (ifStatement.elseBody().isEmpty()) {
+			return Optional.empty();
+		}
+		return ifStatement.elseBody().get().accept(this);
+	}
+
+	@Override
+	public Optional<Returns> visit(SReturnStatement returnStatement) {
+		return Optional.of(Returns.YES);
+	}
+
+	@Override
+	public Optional<Returns> visit(SBlock block) throws SemanticException {
+		for (SStatement statement : block.statements()) {
+			// This statement always returns so the rest is unreachable code, and we can bail out.
+			if (statement.accept(this).isPresent()) {
+				return Optional.of(Returns.YES);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public enum Returns {
+		YES
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/MethodReturnsVisitor.java
@@ -7,6 +7,7 @@ import com.github.firmwehr.gentle.semantic.ast.statement.SBlock;
 import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
 import com.github.firmwehr.gentle.source.Source;
 
 import java.util.Optional;
@@ -22,7 +23,6 @@ import java.util.Optional;
  * </ol>
  * Additionally, the {@link SReturnStatement} is marked to always return and acts as the starting point.
  */
-@SuppressWarnings("ClassCanBeRecord")
 public class MethodReturnsVisitor implements Visitor<MethodReturnsVisitor.Returns> {
 	private final Source source;
 
@@ -58,6 +58,13 @@ public class MethodReturnsVisitor implements Visitor<MethodReturnsVisitor.Return
 			return Optional.empty();
 		}
 		return ifStatement.elseBody().get().accept(this);
+	}
+
+	@Override
+	public Optional<Returns> visit(SWhileStatement whileStatement) throws SemanticException {
+		// We do not need to visit a "while" statement as the condition might be false and therefore it won't
+		// *definitely* return.
+		return Optional.empty();
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -1,0 +1,35 @@
+package com.github.firmwehr.gentle.semantic.analysis;
+
+import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
+import com.github.firmwehr.gentle.source.Source;
+
+import java.util.Optional;
+
+/**
+ * Ensures every {@link SExpressionStatement} has a side effect.
+ */
+@SuppressWarnings("ClassCanBeRecord")
+public class SideEffectVisitor implements Visitor<Void> {
+	private final Source source;
+
+	public SideEffectVisitor(Source source) {
+		this.source = source;
+	}
+
+	@SuppressWarnings("DuplicateBranchesInSwitch")
+	@Override
+	public Optional<Void> visit(SExpressionStatement expressionStatement) throws SemanticException {
+		SExpression expression = expressionStatement.expression();
+		return switch (expression) {
+			case SMethodInvocationExpression ignored -> Optional.empty();
+			case SBinaryOperatorExpression op && op.operator() == BinaryOperator.ASSIGN -> Optional.empty();
+			default -> throw new SemanticException(source, null, "Expression statement must habe side " + "effects");
+		};
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -29,7 +29,7 @@ public class SideEffectVisitor implements Visitor<Void> {
 		return switch (expression) {
 			case SMethodInvocationExpression ignored -> Optional.empty();
 			case SBinaryOperatorExpression op && op.operator() == BinaryOperator.ASSIGN -> Optional.empty();
-			default -> throw new SemanticException(source, null, "Expression must have side effects");
+			default -> throw new SemanticException(source, expression.sourceSpan(), "must have side effects");
 		};
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -14,11 +14,16 @@ import java.util.Optional;
 /**
  * Ensures every {@link SExpressionStatement} has a side effect.
  */
-public class SideEffectVisitor implements Visitor<Void> {
+public class SideEffectVisitor implements Visitor<Optional<Void>> {
 	private final Source source;
 
 	public SideEffectVisitor(Source source) {
 		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> defaultReturnValue() {
+		return Optional.empty();
 	}
 
 	@SuppressWarnings("DuplicateBranchesInSwitch")

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -29,7 +29,7 @@ public class SideEffectVisitor implements Visitor<Void> {
 		return switch (expression) {
 			case SMethodInvocationExpression ignored -> Optional.empty();
 			case SBinaryOperatorExpression op && op.operator() == BinaryOperator.ASSIGN -> Optional.empty();
-			default -> throw new SemanticException(source, null, "Expression statement must habe side " + "effects");
+			default -> throw new SemanticException(source, null, "Expression must have side effects");
 		};
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -6,6 +6,10 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemInReadExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutFlushExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrintlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SExpressionStatement;
 import com.github.firmwehr.gentle.source.Source;
 
@@ -33,6 +37,10 @@ public class SideEffectVisitor implements Visitor<Optional<Void>> {
 		return switch (expression) {
 			case SMethodInvocationExpression ignored -> Optional.empty();
 			case SBinaryOperatorExpression op && op.operator() == BinaryOperator.ASSIGN -> Optional.empty();
+			case SSystemInReadExpression ignored -> Optional.empty();
+			case SSystemOutPrintlnExpression ignored -> Optional.empty();
+			case SSystemOutWriteExpression ignored -> Optional.empty();
+			case SSystemOutFlushExpression ignored -> Optional.empty();
 			default -> throw new SemanticException(source, expression.sourceSpan(), "must have side effects");
 		};
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/SideEffectVisitor.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 /**
  * Ensures every {@link SExpressionStatement} has a side effect.
  */
-@SuppressWarnings("ClassCanBeRecord")
 public class SideEffectVisitor implements Visitor<Void> {
 	private final Source source;
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -189,10 +189,10 @@ public class TypecheckVisitor implements Visitor<Optional<Void>> {
 			SExpression argument = arguments.get(i);
 			LocalVariableDeclaration parameter = parameters.get(i);
 
-			if (!argument.type().isAssignableTo(parameter.getType())) {
+			if (!argument.type().isAssignableTo(parameter.type())) {
 				throw new SemanticException(source, methodInvocationExpression.postfixSpan(),
 					"invalid call, incompatible types", argument.sourceSpan(), "has type " + argument.type().format(),
-					parameter.getTypeSpan(), "expected this type");
+					parameter.typeSpan(), "expected this type");
 			}
 		}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -40,13 +40,18 @@ import java.util.Optional;
  *     <li>The returned value is assignable to the return type</li>
  * </ul>
  */
-public class TypecheckVisitor implements Visitor<Void> {
+public class TypecheckVisitor implements Visitor<Optional<Void>> {
 	private final Source source;
 
 	private SMethod currentMethod;
 
 	public TypecheckVisitor(Source source) {
 		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> defaultReturnValue() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -67,18 +67,21 @@ public class TypecheckVisitor implements Visitor<Void> {
 	@Override
 	public Optional<Void> visit(SWhileStatement whileStatement) throws SemanticException {
 		assertIsBoolean(whileStatement.condition());
+
 		return Visitor.super.visit(whileStatement);
 	}
 
 	@Override
 	public Optional<Void> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
 		assertIsInt(arrayExpression.expression());
+
 		return Visitor.super.visit(arrayExpression);
 	}
 
 	@Override
 	public Optional<Void> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
 		assertIsInt(newArrayExpression.size());
+
 		return Visitor.super.visit(newArrayExpression);
 	}
 
@@ -87,6 +90,7 @@ public class TypecheckVisitor implements Visitor<Void> {
 		switch (unaryOperatorExpression.operator()) {
 			case LOGICAL_NOT, NEGATION -> assertIsBoolean(unaryOperatorExpression.expression());
 		}
+
 		return Visitor.super.visit(unaryOperatorExpression);
 	}
 
@@ -96,6 +100,7 @@ public class TypecheckVisitor implements Visitor<Void> {
 			case ASSIGN -> {
 				SExprType rhsType = binaryOperatorExpression.rhs().type();
 				SExprType lhsType = binaryOperatorExpression.lhs().type();
+
 				if (!rhsType.isAssignableTo(lhsType)) {
 					throw new SemanticException(source, null, "Assignment of incompatible type");
 				}
@@ -117,24 +122,26 @@ public class TypecheckVisitor implements Visitor<Void> {
 				assertIsInt(binaryOperatorExpression.rhs());
 			}
 		}
+
 		return Visitor.super.visit(binaryOperatorExpression);
 	}
 
 	@Override
 	public Optional<Void> visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
 		assertIsInt(systemOutWriteExpression.argument());
+
 		return Visitor.super.visit(systemOutWriteExpression);
 	}
 
 	@Override
 	public Optional<Void> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
 		assertIsInt(systemOutPrinlnExpression.argument());
+
 		return Visitor.super.visit(systemOutPrinlnExpression);
 	}
 
 	@Override
 	public Optional<Void> visit(SMethodInvocationExpression methodInvocationExpression) throws SemanticException {
-
 		SMethod target = methodInvocationExpression.method();
 		List<LocalVariableDeclaration> parameters = target.parameters();
 		List<SExpression> arguments = methodInvocationExpression.arguments();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -164,16 +164,20 @@ public class TypecheckVisitor implements Visitor<Void> {
 		if (currentMethod == null) {
 			throw new IllegalStateException("Return outside of method");
 		}
-		Optional<SExpression> returnValue = returnStatement.returnValue();
+		Optional<SExpression> returnStatementValue = returnStatement.returnValue();
 
-		if (returnValue.isEmpty()) {
-			if (returnStatement.returnValue().isPresent()) {
+		if (currentMethod.returnType().asExprType().asVoidType().isPresent()) {
+			if (returnStatementValue.isPresent()) {
 				throw new SemanticException(source, null, "Void method must not return anything");
 			}
 			return Visitor.super.visit(returnStatement);
 		}
 
-		if (!returnValue.get().type().isAssignableTo(currentMethod.returnType().asExprType())) {
+		if (returnStatementValue.isEmpty()) {
+			throw new SemanticException(source, null, "Non-void methods need to return a value");
+		}
+
+		if (!returnStatementValue.get().type().isAssignableTo(currentMethod.returnType().asExprType())) {
 			throw new SemanticException(source, null, "Not assignable to return type");
 		}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -1,0 +1,213 @@
+package com.github.firmwehr.gentle.semantic.analysis;
+
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
+import com.github.firmwehr.gentle.semantic.ast.SMethod;
+import com.github.firmwehr.gentle.semantic.ast.expression.SArrayAccessExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SBinaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrinlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
+import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
+import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
+import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.Source;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Verifies the program typechecks by ensuring:
+ * <ul>
+ *     <li>If and while conditions are boolean</li>
+ *     <li>Array access indices are integers</li>
+ *     <li>Array size is integer</li>
+ *     <li>Unary logical operators operate on booleans</li>
+ *     <li>System out/println receive integers</li>
+ *     <li>No instances of String objects are created</li>
+ *     <li>The rhs of an assignment is assignable to the lhs</li>
+ *     <li>Either the lhs is assignable to the rhs or vice versa for equality comparisons</li>
+ *     <li>Logical binary expressions operate on booleans</li>
+ *     <li>Mathematical expressions operate on integers</li>
+ *     <li>There are as many method call arguments as parameters and the argument types are assignable to the
+ *     parameter types</li>
+ *     <li>Void method return nothing</li>
+ *     <li>The returned value is assignable to the return type</li>
+ * </ul>
+ */
+public class TypecheckVisitor implements Visitor<Void> {
+	private final Source source;
+
+	private SMethod currentMethod;
+
+	public TypecheckVisitor(Source source) {
+		this.source = source;
+	}
+
+	@Override
+	public Optional<Void> visit(SMethod method) throws SemanticException {
+		this.currentMethod = method;
+		return Visitor.super.visit(method);
+	}
+
+	@Override
+	public Optional<Void> visit(SIfStatement ifStatement) throws SemanticException {
+		assertIsBoolean(ifStatement.condition());
+
+		return Visitor.super.visit(ifStatement);
+	}
+
+	@Override
+	public Optional<Void> visit(SWhileStatement whileStatement) throws SemanticException {
+		assertIsBoolean(whileStatement.condition());
+		return Visitor.super.visit(whileStatement);
+	}
+
+	@Override
+	public Optional<Void> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
+		assertIsInt(arrayExpression.expression());
+		return Visitor.super.visit(arrayExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
+		assertIsInt(newArrayExpression.size());
+		return Visitor.super.visit(newArrayExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SUnaryOperatorExpression unaryOperatorExpression) throws SemanticException {
+		switch (unaryOperatorExpression.operator()) {
+			case LOGICAL_NOT, NEGATION -> assertIsBoolean(unaryOperatorExpression.expression());
+		}
+		return Visitor.super.visit(unaryOperatorExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SBinaryOperatorExpression binaryOperatorExpression) throws SemanticException {
+		switch (binaryOperatorExpression.operator()) {
+			case ASSIGN -> {
+				SExprType rhsType = binaryOperatorExpression.rhs().type();
+				SExprType lhsType = binaryOperatorExpression.lhs().type();
+				if (!rhsType.isAssignableTo(lhsType)) {
+					throw new SemanticException(source, null, "Assignment of incompatible type");
+				}
+			}
+			case EQUAL, NOT_EQUAL -> {
+				SExprType rhsType = binaryOperatorExpression.rhs().type();
+				SExprType lhsType = binaryOperatorExpression.lhs().type();
+
+				if (!lhsType.isAssignableTo(rhsType) && !rhsType.isAssignableTo(lhsType)) {
+					throw new SemanticException(source, null, "Incompatible types in comparison");
+				}
+			}
+			case LOGICAL_OR, LOGICAL_AND -> {
+				assertIsBoolean(binaryOperatorExpression.lhs());
+				assertIsBoolean(binaryOperatorExpression.rhs());
+			}
+			case LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL, ADD, SUBTRACT, MULTIPLY, DIVIDE, MODULO -> {
+				assertIsInt(binaryOperatorExpression.lhs());
+				assertIsInt(binaryOperatorExpression.rhs());
+			}
+		}
+		return Visitor.super.visit(binaryOperatorExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SSystemOutWriteExpression systemOutWriteExpression) throws SemanticException {
+		assertIsInt(systemOutWriteExpression.argument());
+		return Visitor.super.visit(systemOutWriteExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
+		assertIsInt(systemOutPrinlnExpression.argument());
+		return Visitor.super.visit(systemOutPrinlnExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SMethodInvocationExpression methodInvocationExpression) throws SemanticException {
+
+		SMethod target = methodInvocationExpression.method();
+		List<LocalVariableDeclaration> parameters = target.parameters();
+		List<SExpression> arguments = methodInvocationExpression.arguments();
+
+		if (parameters.size() != arguments.size()) {
+			throw new SemanticException(source, null, "Received wrong number of arguments");
+		}
+
+		for (int i = 0; i < parameters.size(); i++) {
+			if (!arguments.get(i).type().isAssignableTo(parameters.get(i).getType())) {
+				throw new SemanticException(source, null, "Mismatched types at index " + i);
+			}
+		}
+
+		return Visitor.super.visit(methodInvocationExpression);
+	}
+
+	@Override
+	public Optional<Void> visit(SReturnStatement returnStatement) throws SemanticException {
+		if (currentMethod == null) {
+			throw new IllegalStateException("Return outside of method");
+		}
+		Optional<SExpression> returnValue = returnStatement.returnValue();
+
+		if (returnValue.isEmpty()) {
+			if (returnStatement.returnValue().isPresent()) {
+				throw new SemanticException(source, null, "Void method must not return anything");
+			}
+			return Visitor.super.visit(returnStatement);
+		}
+
+		if (!returnValue.get().type().isAssignableTo(currentMethod.returnType().asExprType())) {
+			throw new SemanticException(source, null, "Not assignable to return type");
+		}
+
+		return Visitor.super.visit(returnStatement);
+	}
+
+	@Override
+	public Optional<Void> visit(SNewObjectExpression newObjectExpression) throws SemanticException {
+		Optional<SNormalType> normalType = newObjectExpression.type().asNormalType();
+
+		if (normalType.isPresent() && normalType.get().arrayLevel() == 0) {
+			if (normalType.get().basicType().asStringType().isPresent()) {
+				throw new SemanticException(source, null, "Can not create instances of String");
+			}
+		}
+
+		return Visitor.super.visit(newObjectExpression);
+	}
+
+	private void assertIsBoolean(SExpression expression) throws SemanticException {
+		Optional<SNormalType> normalType = expression.type().asNormalType();
+
+		if (normalType.isEmpty() || normalType.get().arrayLevel() != 0) {
+			throw new SemanticException(source, null, "Condition must be a boolean");
+		}
+
+		if (normalType.get().basicType().asBooleanType().isEmpty()) {
+			throw new SemanticException(source, null, "Condition must be a boolean");
+		}
+	}
+
+	private void assertIsInt(SExpression expression) throws SemanticException {
+		Optional<SNormalType> normalType = expression.type().asNormalType();
+
+		if (normalType.isEmpty() || normalType.get().arrayLevel() != 0) {
+			throw new SemanticException(source, null, "Expression must be an integer");
+		}
+
+		if (normalType.get().basicType().asIntType().isEmpty()) {
+			throw new SemanticException(source, null, "Expression must be an integer");
+		}
+	}
+
+}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -16,6 +16,7 @@ import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SReturnStatement;
 import com.github.firmwehr.gentle.semantic.ast.statement.SWhileStatement;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.source.Source;
 
@@ -70,7 +71,21 @@ public class TypecheckVisitor implements Visitor<Void> {
 
 	@Override
 	public Optional<Void> visit(SArrayAccessExpression arrayExpression) throws SemanticException {
-		assertIsInt(arrayExpression.expression());
+		SExpression expression = arrayExpression.expression();
+
+		Optional<SNormalType> hasType = expression.type().asNormalType();
+		SNormalType expectedType = arrayExpression.type();
+
+		if (hasType.isEmpty() || hasType.get().arrayLevel() == 0 ||
+			hasType.get().arrayLevel() != expectedType.arrayLevel() + 1 ||
+			!hasType.get().basicType().equals(expectedType.basicType())) {
+
+			throw new SemanticException(source, arrayExpression.sourceSpan(), "invalid array access",
+				expression.sourceSpan(),
+				"has type " + expression.type().format() + ", expected type " + expectedType.format());
+		}
+
+		assertIsInt(arrayExpression.index());
 
 		return Visitor.super.visit(arrayExpression);
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -10,7 +10,7 @@ import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SMethodInvocationExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewArrayExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SNewObjectExpression;
-import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrinlnExpression;
+import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutPrintlnExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SSystemOutWriteExpression;
 import com.github.firmwehr.gentle.semantic.ast.expression.SUnaryOperatorExpression;
 import com.github.firmwehr.gentle.semantic.ast.statement.SIfStatement;
@@ -134,10 +134,10 @@ public class TypecheckVisitor implements Visitor<Void> {
 	}
 
 	@Override
-	public Optional<Void> visit(SSystemOutPrinlnExpression systemOutPrinlnExpression) throws SemanticException {
-		assertIsInt(systemOutPrinlnExpression.argument());
+	public Optional<Void> visit(SSystemOutPrintlnExpression systemOutPrintlnExpression) throws SemanticException {
+		assertIsInt(systemOutPrintlnExpression.argument());
 
-		return Visitor.super.visit(systemOutPrinlnExpression);
+		return Visitor.super.visit(systemOutPrintlnExpression);
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -150,13 +150,23 @@ public class TypecheckVisitor implements Visitor<Void> {
 		List<LocalVariableDeclaration> parameters = target.parameters();
 		List<SExpression> arguments = methodInvocationExpression.arguments();
 
-		if (parameters.size() != arguments.size()) {
-			throw new SemanticException(source, null, "Received wrong number of arguments");
+		if (arguments.size() < parameters.size()) {
+			throw new SemanticException(source, methodInvocationExpression.postfixSpan(), "too few arguments",
+				target.name().sourceSpan(), "has " + parameters.size() + " parameters");
+		}
+		if (arguments.size() > parameters.size()) {
+			throw new SemanticException(source, methodInvocationExpression.postfixSpan(), "too many arguments",
+				target.name().sourceSpan(), "has " + parameters.size() + " parameters");
 		}
 
 		for (int i = 0; i < parameters.size(); i++) {
-			if (!arguments.get(i).type().isAssignableTo(parameters.get(i).getType())) {
-				throw new SemanticException(source, null, "Mismatched types at index " + i);
+			SExpression argument = arguments.get(i);
+			LocalVariableDeclaration parameter = parameters.get(i);
+
+			if (!argument.type().isAssignableTo(parameter.getType())) {
+				throw new SemanticException(source, methodInvocationExpression.postfixSpan(),
+					"invalid call, incompatible types", argument.sourceSpan(), "has type " + argument.type().format(),
+					parameter.getTypeSpan(), "expected this type");
 			}
 		}
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/analysis/TypecheckVisitor.java
@@ -92,6 +92,12 @@ public class TypecheckVisitor implements Visitor<Void> {
 
 	@Override
 	public Optional<Void> visit(SNewArrayExpression newArrayExpression) throws SemanticException {
+		// This shouldn't happen since the parser should never produce a NewArrayExpression with array level 0, but
+		// better check again to be sure
+		if (newArrayExpression.type().arrayLevel() == 0) {
+			throw new IllegalArgumentException("Creating non-array array");
+		}
+
 		assertIsInt(newArrayExpression.size());
 
 		return Visitor.super.visit(newArrayExpression);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
@@ -9,31 +9,11 @@ import com.github.firmwehr.gentle.source.SourceSpan;
  * <br>
  * This class uses <em>reference equality</em> semantics.
  */
-public class LocalVariableDeclaration {
-	private final SNormalType type;
-	private final SourceSpan typeSpan;
-	private final Ident declaration;
-
-	public LocalVariableDeclaration(
-		SNormalType type, SourceSpan typeSpan, Ident declaration
-	) {
-		this.type = type;
-		this.typeSpan = typeSpan;
-		this.declaration = declaration;
-	}
-
-	public SNormalType getType() {
-		return type;
-	}
-
-	public SourceSpan getTypeSpan() {
-		return typeSpan;
-	}
-
-	public Ident getDeclaration() {
-		return declaration;
-	}
-
+public record LocalVariableDeclaration(
+	SNormalType type,
+	SourceSpan typeSpan,
+	Ident declaration
+) {
 	@Override
 	public boolean equals(Object o) {
 		return this == o;

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
@@ -2,19 +2,28 @@ package com.github.firmwehr.gentle.semantic.ast;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 @SuppressWarnings("ClassCanBeRecord")
 public class LocalVariableDeclaration {
 	private final SNormalType type;
+	private final SourceSpan typeSpan;
 	private final Ident declaration;
 
-	public LocalVariableDeclaration(SNormalType type, Ident declaration) {
+	public LocalVariableDeclaration(
+		SNormalType type, SourceSpan typeSpan, Ident declaration
+	) {
 		this.type = type;
+		this.typeSpan = typeSpan;
 		this.declaration = declaration;
 	}
 
 	public SNormalType getType() {
 		return type;
+	}
+
+	public SourceSpan getTypeSpan() {
+		return typeSpan;
 	}
 
 	public Ident getDeclaration() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
@@ -4,7 +4,6 @@ import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-@SuppressWarnings("ClassCanBeRecord")
 public class LocalVariableDeclaration {
 	private final SNormalType type;
 	private final SourceSpan typeSpan;

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/LocalVariableDeclaration.java
@@ -4,6 +4,11 @@ import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
+/**
+ * A declaration of a local variable or parameter.
+ * <br>
+ * This class uses <em>reference equality</em> semantics.
+ */
 public class LocalVariableDeclaration {
 	private final SNormalType type;
 	private final SourceSpan typeSpan;
@@ -27,5 +32,15 @@ public class LocalVariableDeclaration {
 
 	public Ident getDeclaration() {
 		return declaration;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return this == o;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SClassDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SClassDeclaration.java
@@ -3,9 +3,24 @@ package com.github.firmwehr.gentle.semantic.ast;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.Namespace;
 
+/**
+ * A declaration of a class.
+ * <br>
+ * This class uses <em>reference equality</em> semantics.
+ */
 public record SClassDeclaration(
 	Ident name,
 	Namespace<SField> fields,
 	Namespace<SMethod> methods
 ) {
+
+	@Override
+	public boolean equals(Object o) {
+		return this == o;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SField.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SField.java
@@ -2,10 +2,12 @@ package com.github.firmwehr.gentle.semantic.ast;
 
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record SField(
 	SClassDeclaration classDecl,
 	Ident name,
-	SNormalType type
+	SNormalType type,
+	SourceSpan typeSpan
 ) {
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SField.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SField.java
@@ -4,10 +4,24 @@ import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
+/**
+ * A declaration of a field.
+ * <br>
+ * This class uses <em>reference equality</em> semantics.
+ */
 public record SField(
 	SClassDeclaration classDecl,
 	Ident name,
 	SNormalType type,
 	SourceSpan typeSpan
 ) {
+	@Override
+	public boolean equals(Object o) {
+		return o == this;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
@@ -15,7 +15,6 @@ public record SMethod(
 	SVoidyType returnType,
 	SourceSpan returnTypeSpan,
 	List<LocalVariableDeclaration> parameters,
-	List<LocalVariableDeclaration> localVariables,
 	List<SStatement> body
 ) {
 	public static SMethod newMethod(
@@ -26,7 +25,6 @@ public record SMethod(
 		SourceSpan returnTypeSpan,
 		List<LocalVariableDeclaration> parameters
 	) {
-		return new SMethod(classDecl, isStatic, name, returnType, returnTypeSpan, parameters, new ArrayList<>(),
-			new ArrayList<>());
+		return new SMethod(classDecl, isStatic, name, returnType, returnTypeSpan, parameters, new ArrayList<>());
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.semantic.ast;
 import com.github.firmwehr.gentle.parser.ast.Ident;
 import com.github.firmwehr.gentle.semantic.ast.statement.SStatement;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidyType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +13,7 @@ public record SMethod(
 	boolean isStatic,
 	Ident name,
 	SVoidyType returnType,
+	SourceSpan returnTypeSpan,
 	List<LocalVariableDeclaration> parameters,
 	List<LocalVariableDeclaration> localVariables,
 	List<SStatement> body
@@ -21,8 +23,10 @@ public record SMethod(
 		boolean isStatic,
 		Ident name,
 		SVoidyType returnType,
+		SourceSpan returnTypeSpan,
 		List<LocalVariableDeclaration> parameters
 	) {
-		return new SMethod(classDecl, isStatic, name, returnType, parameters, new ArrayList<>(), new ArrayList<>());
+		return new SMethod(classDecl, isStatic, name, returnType, returnTypeSpan, parameters, new ArrayList<>(),
+			new ArrayList<>());
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SMethod.java
@@ -8,6 +8,11 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A declaration of a method.
+ * <br>
+ * This class uses <em>reference equality</em> semantics.
+ */
 public record SMethod(
 	SClassDeclaration classDecl,
 	boolean isStatic,
@@ -26,5 +31,15 @@ public record SMethod(
 		List<LocalVariableDeclaration> parameters
 	) {
 		return new SMethod(classDecl, isStatic, name, returnType, returnTypeSpan, parameters, new ArrayList<>());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return o == this;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/SProgram.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/SProgram.java
@@ -2,8 +2,22 @@ package com.github.firmwehr.gentle.semantic.ast;
 
 import com.github.firmwehr.gentle.semantic.Namespace;
 
+/**
+ * A complete program consisting of a set of classes and a main method.
+ * <br>
+ * This class uses <em>reference equality</em> semantics.
+ */
 public record SProgram(
 	Namespace<SClassDeclaration> classes,
 	SMethod mainMethod
 ) {
+	@Override
+	public boolean equals(Object o) {
+		return o == this;
+	}
+
+	@Override
+	public int hashCode() {
+		return System.identityHashCode(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBasicType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBasicType.java
@@ -1,4 +1,24 @@
 package com.github.firmwehr.gentle.semantic.ast.basictype;
 
+import java.util.Optional;
+
 public sealed interface SBasicType permits SBooleanType, SClassType, SIntType, SStringType {
+
+	default Optional<SBooleanType> asBooleanType() {
+		return Optional.empty();
+	}
+
+	default Optional<SClassType> asClassType() {
+		return Optional.empty();
+	}
+
+	default Optional<SIntType> asIntType() {
+		return Optional.empty();
+	}
+
+	default Optional<SStringType> asStringType() {
+		return Optional.empty();
+	}
+
+	boolean isAssignableFrom(SBasicType other);
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBasicType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBasicType.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.semantic.ast.basictype;
 import java.util.Optional;
 
 public sealed interface SBasicType permits SBooleanType, SClassType, SIntType, SStringType {
+	String format();
 
 	default Optional<SBooleanType> asBooleanType() {
 		return Optional.empty();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBooleanType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBooleanType.java
@@ -1,4 +1,16 @@
 package com.github.firmwehr.gentle.semantic.ast.basictype;
 
+import java.util.Optional;
+
 public record SBooleanType() implements SBasicType {
+
+	@Override
+	public Optional<SBooleanType> asBooleanType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableFrom(SBasicType other) {
+		return other.asBooleanType().isPresent();
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBooleanType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SBooleanType.java
@@ -3,6 +3,10 @@ package com.github.firmwehr.gentle.semantic.ast.basictype;
 import java.util.Optional;
 
 public record SBooleanType() implements SBasicType {
+	@Override
+	public String format() {
+		return "boolean";
+	}
 
 	@Override
 	public Optional<SBooleanType> asBooleanType() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
@@ -2,5 +2,18 @@ package com.github.firmwehr.gentle.semantic.ast.basictype;
 
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 
+import java.util.Optional;
+
 public record SClassType(SClassDeclaration classDecl) implements SBasicType {
+
+	@Override
+	public Optional<SClassType> asClassType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableFrom(SBasicType other) {
+		// TODO: Is Singleton?
+		return other.asClassType().map(classType -> classType.classDecl() == classDecl()).orElse(false);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
@@ -13,7 +13,6 @@ public record SClassType(SClassDeclaration classDecl) implements SBasicType {
 
 	@Override
 	public boolean isAssignableFrom(SBasicType other) {
-		// TODO: Is Singleton?
 		return other.asClassType().map(classType -> classType.classDecl() == classDecl()).orElse(false);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SClassType.java
@@ -5,6 +5,10 @@ import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import java.util.Optional;
 
 public record SClassType(SClassDeclaration classDecl) implements SBasicType {
+	@Override
+	public String format() {
+		return classDecl.name().ident();
+	}
 
 	@Override
 	public Optional<SClassType> asClassType() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SIntType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SIntType.java
@@ -1,4 +1,16 @@
 package com.github.firmwehr.gentle.semantic.ast.basictype;
 
+import java.util.Optional;
+
 public record SIntType() implements SBasicType {
+
+	@Override
+	public Optional<SIntType> asIntType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableFrom(SBasicType other) {
+		return other.asIntType().isPresent();
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SIntType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SIntType.java
@@ -3,6 +3,10 @@ package com.github.firmwehr.gentle.semantic.ast.basictype;
 import java.util.Optional;
 
 public record SIntType() implements SBasicType {
+	@Override
+	public String format() {
+		return "int";
+	}
 
 	@Override
 	public Optional<SIntType> asIntType() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SStringType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SStringType.java
@@ -3,6 +3,10 @@ package com.github.firmwehr.gentle.semantic.ast.basictype;
 import java.util.Optional;
 
 public record SStringType() implements SBasicType {
+	@Override
+	public String format() {
+		return "String";
+	}
 
 	@Override
 	public Optional<SStringType> asStringType() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SStringType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/basictype/SStringType.java
@@ -1,4 +1,16 @@
 package com.github.firmwehr.gentle.semantic.ast.basictype;
 
+import java.util.Optional;
+
 public record SStringType() implements SBasicType {
+
+	@Override
+	public Optional<SStringType> asStringType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableFrom(SBasicType other) {
+		return other.asStringType().isPresent();
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
@@ -5,8 +5,6 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SArrayAccessExpression(
 	SExpression expression,
 	SExpression index,
@@ -14,7 +12,7 @@ public record SArrayAccessExpression(
 	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
@@ -1,10 +1,18 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SArrayAccessExpression(
 	SExpression expression,
 	SExpression index,
 	SNormalType type
 ) implements SExpression {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SArrayAccessExpression.java
@@ -3,13 +3,15 @@ package com.github.firmwehr.gentle.semantic.ast.expression;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SArrayAccessExpression(
 	SExpression expression,
 	SExpression index,
-	SNormalType type
+	SNormalType type,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
@@ -4,6 +4,7 @@ import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
@@ -11,7 +12,8 @@ public record SBinaryOperatorExpression(
 	SExpression lhs,
 	SExpression rhs,
 	BinaryOperator operator,
-	SExprType type
+	SExprType type,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
@@ -9,8 +9,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SBinaryOperatorExpression(
 	SExpression lhs,
 	SExpression rhs,
@@ -28,7 +26,7 @@ public record SBinaryOperatorExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
@@ -3,7 +3,10 @@ package com.github.firmwehr.gentle.semantic.ast.expression;
 import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
@@ -12,9 +15,18 @@ public record SBinaryOperatorExpression(
 	SExpression lhs,
 	SExpression rhs,
 	BinaryOperator operator,
-	SExprType type,
 	SourceSpan sourceSpan
 ) implements SExpression {
+	@Override
+	public SExprType type() {
+		return switch (operator) {
+			case ASSIGN -> rhs.type();
+			case LOGICAL_OR, LOGICAL_AND, EQUAL, NOT_EQUAL, LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL -> new SNormalType(
+				new SBooleanType());
+			case ADD, SUBTRACT, MULTIPLY, DIVIDE, MODULO -> new SNormalType(new SIntType());
+		};
+	}
+
 	@Override
 	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
@@ -18,7 +18,7 @@ public record SBinaryOperatorExpression(
 	@Override
 	public SExprType type() {
 		return switch (operator) {
-			case ASSIGN -> rhs.type();
+			case ASSIGN -> lhs.type();
 			case LOGICAL_OR, LOGICAL_AND, EQUAL, NOT_EQUAL, LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL -> new SNormalType(
 				new SBooleanType());
 			case ADD, SUBTRACT, MULTIPLY, DIVIDE, MODULO -> new SNormalType(new SIntType());

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBinaryOperatorExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+
+import java.util.Optional;
 
 public record SBinaryOperatorExpression(
 	SExpression lhs,
@@ -9,4 +13,8 @@ public record SBinaryOperatorExpression(
 	BinaryOperator operator,
 	SExprType type
 ) implements SExpression {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
@@ -1,8 +1,12 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SBooleanValueExpression(
 	boolean value
@@ -10,5 +14,10 @@ public record SBooleanValueExpression(
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SBooleanType());
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
@@ -7,8 +7,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SBooleanValueExpression(
 	boolean value,
 	SourceSpan sourceSpan
@@ -19,7 +17,7 @@ public record SBooleanValueExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SBooleanValueExpression.java
@@ -5,11 +5,13 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SBooleanValueExpression(
-	boolean value
+	boolean value,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
@@ -5,8 +5,6 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public sealed interface SExpression
 	permits SArrayAccessExpression, SBinaryOperatorExpression, SBooleanValueExpression, SFieldAccessExpression,
 	        SIntegerValueExpression, SLocalVariableExpression, SMethodInvocationExpression, SNewArrayExpression,
@@ -17,5 +15,5 @@ public sealed interface SExpression
 
 	SExprType type();
 
-	<T> Optional<T> accept(Visitor<T> visitor) throws SemanticException;
+	<T> T accept(Visitor<T> visitor) throws SemanticException;
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
@@ -10,7 +10,7 @@ public sealed interface SExpression
 	permits SArrayAccessExpression, SBinaryOperatorExpression, SBooleanValueExpression, SFieldAccessExpression,
 	        SIntegerValueExpression, SLocalVariableExpression, SMethodInvocationExpression, SNewArrayExpression,
 	        SNewObjectExpression, SNullExpression, SSystemInReadExpression, SSystemOutFlushExpression,
-	        SSystemOutPrinlnExpression, SSystemOutWriteExpression, SThisExpression, SUnaryOperatorExpression {
+	        SSystemOutPrintlnExpression, SSystemOutWriteExpression, SThisExpression, SUnaryOperatorExpression {
 
 	SExprType type();
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
@@ -1,6 +1,10 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+
+import java.util.Optional;
 
 public sealed interface SExpression
 	permits SArrayAccessExpression, SBinaryOperatorExpression, SBooleanValueExpression, SFieldAccessExpression,
@@ -9,4 +13,6 @@ public sealed interface SExpression
 	        SSystemOutPrinlnExpression, SSystemOutWriteExpression, SThisExpression, SUnaryOperatorExpression {
 
 	SExprType type();
+
+	<T> Optional<T> accept(Visitor<T> visitor) throws SemanticException;
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SExpression.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.semantic.ast.expression;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
@@ -11,6 +12,8 @@ public sealed interface SExpression
 	        SIntegerValueExpression, SLocalVariableExpression, SMethodInvocationExpression, SNewArrayExpression,
 	        SNewObjectExpression, SNullExpression, SSystemInReadExpression, SSystemOutFlushExpression,
 	        SSystemOutPrintlnExpression, SSystemOutWriteExpression, SThisExpression, SUnaryOperatorExpression {
+
+	SourceSpan sourceSpan();
 
 	SExprType type();
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.SField;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SFieldAccessExpression(
 	SExpression expression,
 	SField field,
@@ -19,7 +17,7 @@ public record SFieldAccessExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
@@ -4,12 +4,14 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SField;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SFieldAccessExpression(
 	SExpression expression,
-	SField field
+	SField field,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SFieldAccessExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SField;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+
+import java.util.Optional;
 
 public record SFieldAccessExpression(
 	SExpression expression,
@@ -10,5 +14,10 @@ public record SFieldAccessExpression(
 	@Override
 	public SExprType type() {
 		return field.type();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
@@ -1,8 +1,12 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SIntegerValueExpression(
 	int value
@@ -10,5 +14,10 @@ public record SIntegerValueExpression(
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SIntType());
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
@@ -7,8 +7,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SIntegerValueExpression(
 	int value,
 	SourceSpan sourceSpan
@@ -19,7 +17,7 @@ public record SIntegerValueExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SIntegerValueExpression.java
@@ -5,11 +5,13 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SIntegerValueExpression(
-	int value
+	int value,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
@@ -4,11 +4,13 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SLocalVariableExpression(
-	LocalVariableDeclaration localVariable
+	LocalVariableDeclaration localVariable,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+
+import java.util.Optional;
 
 public record SLocalVariableExpression(
 	LocalVariableDeclaration localVariable
@@ -9,5 +13,10 @@ public record SLocalVariableExpression(
 	@Override
 	public SExprType type() {
 		return localVariable.getType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.LocalVariableDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SLocalVariableExpression(
 	LocalVariableDeclaration localVariable,
 	SourceSpan sourceSpan
@@ -18,7 +16,7 @@ public record SLocalVariableExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SLocalVariableExpression.java
@@ -12,7 +12,7 @@ public record SLocalVariableExpression(
 ) implements SExpression {
 	@Override
 	public SExprType type() {
-		return localVariable.getType();
+		return localVariable.type();
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
@@ -1,9 +1,12 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SMethod;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 
 import java.util.List;
+import java.util.Optional;
 
 public record SMethodInvocationExpression(
 	SExpression expression,
@@ -13,5 +16,10 @@ public record SMethodInvocationExpression(
 	@Override
 	public SExprType type() {
 		return method.returnType().asExprType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
@@ -7,7 +7,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * @param postfixSpan span from the beginning of the name to the closing parenthesis
@@ -25,7 +24,7 @@ public record SMethodInvocationExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
@@ -4,6 +4,7 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SMethod;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +12,8 @@ import java.util.Optional;
 public record SMethodInvocationExpression(
 	SExpression expression,
 	SMethod method,
-	List<SExpression> arguments
+	List<SExpression> arguments,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SMethodInvocationExpression.java
@@ -9,10 +9,14 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * @param postfixSpan span from the beginning of the name to the closing parenthesis
+ */
 public record SMethodInvocationExpression(
 	SExpression expression,
 	SMethod method,
 	List<SExpression> arguments,
+	SourceSpan postfixSpan,
 	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
@@ -1,9 +1,17 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SNewArrayExpression(
 	SNormalType type,
 	SExpression size
 ) implements SExpression {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
@@ -3,12 +3,14 @@ package com.github.firmwehr.gentle.semantic.ast.expression;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SNewArrayExpression(
 	SNormalType type,
-	SExpression size
+	SExpression size,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewArrayExpression.java
@@ -5,15 +5,13 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SNewArrayExpression(
 	SNormalType type,
 	SExpression size,
 	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
@@ -8,8 +8,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SNewObjectExpression(
 	SClassDeclaration classDecl,
 	SourceSpan sourceSpan
@@ -20,7 +18,7 @@ public record SNewObjectExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
@@ -1,9 +1,13 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SNewObjectExpression(
 	SClassDeclaration classDecl
@@ -11,5 +15,10 @@ public record SNewObjectExpression(
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SClassType(classDecl));
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNewObjectExpression.java
@@ -6,11 +6,13 @@ import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SNewObjectExpression(
-	SClassDeclaration classDecl
+	SClassDeclaration classDecl,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
@@ -1,11 +1,20 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNullType;
+
+import java.util.Optional;
 
 public record SNullExpression() implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNullType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
@@ -4,10 +4,11 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNullType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record SNullExpression() implements SExpression {
+public record SNullExpression(SourceSpan sourceSpan) implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNullType();

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SNullExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNullType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SNullExpression(SourceSpan sourceSpan) implements SExpression {
 	@Override
 	public SExprType type() {
@@ -15,7 +13,7 @@ public record SNullExpression(SourceSpan sourceSpan) implements SExpression {
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
@@ -7,8 +7,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SSystemInReadExpression(SourceSpan sourceSpan) implements SExpression {
 	@Override
 	public SExprType type() {
@@ -16,7 +14,7 @@ public record SSystemInReadExpression(SourceSpan sourceSpan) implements SExpress
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
@@ -1,12 +1,21 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+
+import java.util.Optional;
 
 public record SSystemInReadExpression() implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SIntType());
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemInReadExpression.java
@@ -5,10 +5,11 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record SSystemInReadExpression() implements SExpression {
+public record SSystemInReadExpression(SourceSpan sourceSpan) implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SIntType());

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
@@ -4,10 +4,11 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record SSystemOutFlushExpression() implements SExpression {
+public record SSystemOutFlushExpression(SourceSpan sourceSpan) implements SExpression {
 
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SSystemOutFlushExpression(SourceSpan sourceSpan) implements SExpression {
 
 	@Override
@@ -16,7 +14,7 @@ public record SSystemOutFlushExpression(SourceSpan sourceSpan) implements SExpre
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutFlushExpression.java
@@ -1,12 +1,21 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+
+import java.util.Optional;
 
 public record SSystemOutFlushExpression() implements SExpression {
 
 	@Override
 	public SExprType type() {
 		return new SVoidType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrinlnExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrinlnExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+
+import java.util.Optional;
 
 public record SSystemOutPrinlnExpression(
 	SExpression argument
@@ -9,5 +13,10 @@ public record SSystemOutPrinlnExpression(
 	@Override
 	public SExprType type() {
 		return new SVoidType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
@@ -4,11 +4,13 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SSystemOutPrintlnExpression(
-	SExpression argument
+	SExpression argument,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
@@ -7,7 +7,7 @@ import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 
 import java.util.Optional;
 
-public record SSystemOutPrinlnExpression(
+public record SSystemOutPrintlnExpression(
 	SExpression argument
 ) implements SExpression {
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutPrintlnExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SSystemOutPrintlnExpression(
 	SExpression argument,
 	SourceSpan sourceSpan
@@ -18,7 +16,7 @@ public record SSystemOutPrintlnExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SSystemOutWriteExpression(
 	SExpression argument,
 	SourceSpan sourceSpan
@@ -18,7 +16,7 @@ public record SSystemOutWriteExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
@@ -4,11 +4,13 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SSystemOutWriteExpression(
-	SExpression argument
+	SExpression argument,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SSystemOutWriteExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SVoidType;
+
+import java.util.Optional;
 
 public record SSystemOutWriteExpression(
 	SExpression argument
@@ -9,5 +13,10 @@ public record SSystemOutWriteExpression(
 	@Override
 	public SExprType type() {
 		return new SVoidType();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
@@ -6,10 +6,14 @@ import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record SThisExpression(SClassDeclaration classDecl) implements SExpression {
+public record SThisExpression(
+	SClassDeclaration classDecl,
+	SourceSpan sourceSpan
+) implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SClassType(classDecl));

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
@@ -1,13 +1,22 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.SClassDeclaration;
 import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 
+import java.util.Optional;
+
 public record SThisExpression(SClassDeclaration classDecl) implements SExpression {
 	@Override
 	public SExprType type() {
 		return new SNormalType(new SClassType(classDecl));
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SThisExpression.java
@@ -8,8 +8,6 @@ import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.semantic.ast.type.SNormalType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SThisExpression(
 	SClassDeclaration classDecl,
 	SourceSpan sourceSpan
@@ -20,7 +18,7 @@ public record SThisExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
@@ -1,7 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.expression;
 
 import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+
+import java.util.Optional;
 
 public record SUnaryOperatorExpression(
 	UnaryOperator operator,
@@ -10,5 +14,10 @@ public record SUnaryOperatorExpression(
 	@Override
 	public SExprType type() {
 		return expression.type();
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
@@ -6,8 +6,6 @@ import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
 import com.github.firmwehr.gentle.source.SourceSpan;
 
-import java.util.Optional;
-
 public record SUnaryOperatorExpression(
 	UnaryOperator operator,
 	SExpression expression,
@@ -19,7 +17,7 @@ public record SUnaryOperatorExpression(
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/expression/SUnaryOperatorExpression.java
@@ -4,12 +4,14 @@ import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.type.SExprType;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
 public record SUnaryOperatorExpression(
 	UnaryOperator operator,
-	SExpression expression
+	SExpression expression,
+	SourceSpan sourceSpan
 ) implements SExpression {
 	@Override
 	public SExprType type() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SBlock.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SBlock.java
@@ -4,7 +4,6 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 
 import java.util.List;
-import java.util.Optional;
 
 public record SBlock(List<SStatement> statements) implements SStatement {
 	public SBlock() {
@@ -12,7 +11,7 @@ public record SBlock(List<SStatement> statements) implements SStatement {
 	}
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SBlock.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SBlock.java
@@ -1,9 +1,18 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+
 import java.util.List;
+import java.util.Optional;
 
 public record SBlock(List<SStatement> statements) implements SStatement {
 	public SBlock() {
 		this(List.of());
+	}
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SExpressionStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SExpressionStatement.java
@@ -4,11 +4,9 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 
-import java.util.Optional;
-
 public record SExpressionStatement(SExpression expression) implements SStatement {
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SExpressionStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SExpressionStatement.java
@@ -1,6 +1,14 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 
+import java.util.Optional;
+
 public record SExpressionStatement(SExpression expression) implements SStatement {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SIfStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SIfStatement.java
@@ -12,7 +12,7 @@ public record SIfStatement(
 	Optional<SStatement> elseBody
 ) implements SStatement {
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SIfStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SIfStatement.java
@@ -1,5 +1,7 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 
 import java.util.Optional;
@@ -9,4 +11,8 @@ public record SIfStatement(
 	SStatement body,
 	Optional<SStatement> elseBody
 ) implements SStatement {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
@@ -3,10 +3,14 @@ package com.github.firmwehr.gentle.semantic.ast.statement;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+import com.github.firmwehr.gentle.source.SourceSpan;
 
 import java.util.Optional;
 
-public record SReturnStatement(Optional<SExpression> returnValue) implements SStatement {
+public record SReturnStatement(
+	Optional<SExpression> returnValue,
+	SourceSpan sourceSpan
+) implements SStatement {
 	@Override
 	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
@@ -1,8 +1,14 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 
 import java.util.Optional;
 
 public record SReturnStatement(Optional<SExpression> returnValue) implements SStatement {
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SReturnStatement.java
@@ -12,7 +12,7 @@ public record SReturnStatement(
 	SourceSpan sourceSpan
 ) implements SStatement {
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SStatement.java
@@ -3,10 +3,8 @@ package com.github.firmwehr.gentle.semantic.ast.statement;
 import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 
-import java.util.Optional;
-
 public sealed interface SStatement
 	permits SBlock, SExpressionStatement, SIfStatement, SReturnStatement, SWhileStatement {
 
-	<T> Optional<T> accept(Visitor<T> visitor) throws SemanticException;
+	<T> T accept(Visitor<T> visitor) throws SemanticException;
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SStatement.java
@@ -1,5 +1,12 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
+
+import java.util.Optional;
+
 public sealed interface SStatement
 	permits SBlock, SExpressionStatement, SIfStatement, SReturnStatement, SWhileStatement {
+
+	<T> Optional<T> accept(Visitor<T> visitor) throws SemanticException;
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SWhileStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SWhileStatement.java
@@ -4,15 +4,13 @@ import com.github.firmwehr.gentle.semantic.SemanticException;
 import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
 
-import java.util.Optional;
-
 public record SWhileStatement(
 	SExpression condition,
 	SStatement body
 ) implements SStatement {
 
 	@Override
-	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+	public <T> T accept(Visitor<T> visitor) throws SemanticException {
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SWhileStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/statement/SWhileStatement.java
@@ -1,9 +1,18 @@
 package com.github.firmwehr.gentle.semantic.ast.statement;
 
+import com.github.firmwehr.gentle.semantic.SemanticException;
+import com.github.firmwehr.gentle.semantic.Visitor;
 import com.github.firmwehr.gentle.semantic.ast.expression.SExpression;
+
+import java.util.Optional;
 
 public record SWhileStatement(
 	SExpression condition,
 	SStatement body
 ) implements SStatement {
+
+	@Override
+	public <T> Optional<T> accept(Visitor<T> visitor) throws SemanticException {
+		return visitor.visit(this);
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
@@ -1,5 +1,11 @@
 package com.github.firmwehr.gentle.semantic.ast.type;
 
+import com.github.firmwehr.gentle.semantic.ast.basictype.SBasicType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SBooleanType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SClassType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SIntType;
+import com.github.firmwehr.gentle.semantic.ast.basictype.SStringType;
+
 import java.util.Optional;
 
 public sealed interface SExprType permits SNormalType, SNullType, SVoidType {
@@ -16,5 +22,25 @@ public sealed interface SExprType permits SNormalType, SNullType, SVoidType {
 
 	default Optional<SVoidType> asVoidType() {
 		return Optional.empty();
+	}
+
+	default Optional<SBasicType> asBasicType() {
+		return asNormalType().filter(t -> t.arrayLevel() == 0).map(SNormalType::basicType);
+	}
+
+	default Optional<SBooleanType> asBooleanType() {
+		return asBasicType().flatMap(SBasicType::asBooleanType);
+	}
+
+	default Optional<SClassType> asClassType() {
+		return asBasicType().flatMap(SBasicType::asClassType);
+	}
+
+	default Optional<SIntType> asIntType() {
+		return asBasicType().flatMap(SBasicType::asIntType);
+	}
+
+	default Optional<SStringType> asStringType() {
+		return asBasicType().flatMap(SBasicType::asStringType);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
@@ -1,4 +1,20 @@
 package com.github.firmwehr.gentle.semantic.ast.type;
 
+import java.util.Optional;
+
 public sealed interface SExprType permits SNormalType, SNullType, SVoidType {
+
+	boolean isAssignableTo(SExprType other);
+
+	default Optional<SNormalType> asNormalType() {
+		return Optional.empty();
+	}
+
+	default Optional<SNullType> asNullType() {
+		return Optional.empty();
+	}
+
+	default Optional<SVoidType> asVoidType() {
+		return Optional.empty();
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SExprType.java
@@ -9,6 +9,7 @@ import com.github.firmwehr.gentle.semantic.ast.basictype.SStringType;
 import java.util.Optional;
 
 public sealed interface SExprType permits SNormalType, SNullType, SVoidType {
+	String format();
 
 	boolean isAssignableTo(SExprType other);
 

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
@@ -29,11 +29,14 @@ public record SNormalType(
 
 	@Override
 	public boolean isAssignableTo(SExprType other) {
-		// FIXME: Respect array level
-		if (!(other instanceof SNormalType)) {
+		if (!(other instanceof SNormalType normalOther)) {
 			return false;
 		}
-		return basicType().isAssignableFrom(((SNormalType) other).basicType());
+
+		if (normalOther.arrayLevel() != arrayLevel()) {
+			return false;
+		}
+		return basicType().isAssignableFrom(normalOther.basicType());
 	}
 
 	public Optional<SNormalType> withDecrementedLevel() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
@@ -22,6 +22,20 @@ public record SNormalType(
 		return this;
 	}
 
+	@Override
+	public Optional<SNormalType> asNormalType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableTo(SExprType other) {
+		// FIXME: Respect array level
+		if (!(other instanceof SNormalType)) {
+			return false;
+		}
+		return basicType().isAssignableFrom(((SNormalType) other).basicType());
+	}
+
 	public Optional<SNormalType> withDecrementedLevel() {
 		if (arrayLevel > 0) {
 			return Optional.of(new SNormalType(basicType, arrayLevel - 1));

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
@@ -18,6 +18,11 @@ public record SNormalType(
 	}
 
 	@Override
+	public String format() {
+		return basicType.format() + "[]".repeat(arrayLevel);
+	}
+
+	@Override
 	public SExprType asExprType() {
 		return this;
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNormalType.java
@@ -32,7 +32,6 @@ public record SNormalType(
 		if (!(other instanceof SNormalType normalOther)) {
 			return false;
 		}
-
 		if (normalOther.arrayLevel() != arrayLevel()) {
 			return false;
 		}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
@@ -3,6 +3,10 @@ package com.github.firmwehr.gentle.semantic.ast.type;
 import java.util.Optional;
 
 public record SNullType() implements SExprType {
+	@Override
+	public String format() {
+		return "null";
+	}
 
 	@Override
 	public Optional<SNullType> asNullType() {

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
@@ -11,9 +11,9 @@ public record SNullType() implements SExprType {
 
 	@Override
 	public boolean isAssignableTo(SExprType other) {
-		if (other instanceof SNormalType type) {
-			return type.basicType().asClassType().isPresent() || type.basicType().asStringType().isPresent();
+		if (other.asNormalType().isPresent() && other.asNormalType().get().arrayLevel() > 0) {
+			return true;
 		}
-		return other instanceof SNullType;
+		return other.asClassType().isPresent() || other.asStringType().isPresent() || other.asNullType().isPresent();
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SNullType.java
@@ -1,4 +1,19 @@
 package com.github.firmwehr.gentle.semantic.ast.type;
 
+import java.util.Optional;
+
 public record SNullType() implements SExprType {
+
+	@Override
+	public Optional<SNullType> asNullType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableTo(SExprType other) {
+		if (other instanceof SNormalType type) {
+			return type.basicType().asClassType().isPresent() || type.basicType().asStringType().isPresent();
+		}
+		return other instanceof SNullType;
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidType.java
@@ -1,8 +1,20 @@
 package com.github.firmwehr.gentle.semantic.ast.type;
 
+import java.util.Optional;
+
 public record SVoidType() implements SExprType, SVoidyType {
 	@Override
 	public SExprType asExprType() {
 		return this;
+	}
+
+	@Override
+	public Optional<SVoidType> asVoidType() {
+		return Optional.of(this);
+	}
+
+	@Override
+	public boolean isAssignableTo(SExprType other) {
+		return false;
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidType.java
@@ -4,6 +4,11 @@ import java.util.Optional;
 
 public record SVoidType() implements SExprType, SVoidyType {
 	@Override
+	public String format() {
+		return "void";
+	}
+
+	@Override
 	public SExprType asExprType() {
 		return this;
 	}

--- a/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidyType.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/ast/type/SVoidyType.java
@@ -2,4 +2,6 @@ package com.github.firmwehr.gentle.semantic.ast.type;
 
 public sealed interface SVoidyType permits SNormalType, SVoidType {
 	SExprType asExprType();
+
+	boolean isAssignableTo(SExprType other);
 }

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -117,14 +117,12 @@ public record Source(String content) {
 	}
 
 	private static void appendRespectingTab(StringBuilder builder, char guide, char toAppend) {
-		if (toAppend == '\t') {
-			toAppend = ' ';
-		}
+		char nonTabToAppend = (toAppend == '\t') ? ' ' : toAppend;
 
 		if (guide == '\t') {
-			builder.append(Character.toString(toAppend).repeat(TAB_WIDTH));
+			builder.append(Character.toString(nonTabToAppend).repeat(TAB_WIDTH));
 		} else {
-			builder.append(toAppend);
+			builder.append(nonTabToAppend);
 		}
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -126,11 +126,4 @@ public record Source(String content) {
 	public String formatErrorAt(String description, int offset, String message) {
 		return description + "\n" + formatMessagePointingTo(offset, message);
 	}
-
-	public String formatErrorWithReferenceAt(
-		String description, int offset, String message, int referenceOffset, String referenceMessage
-	) {
-		return description + "\n" + formatMessagePointingTo(offset, message) + "\n\n" +
-			formatMessagePointingTo(referenceOffset, referenceMessage);
-	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -222,11 +222,14 @@ public record Source(String content) {
 		codeLine.append(("%" + lineNrWidth + "d").formatted(endLineNr)).append(" | | ");
 		noteLine.append(" ".repeat(lineNrWidth)).append(" | `-");
 
-		for (int i = 0; i < line.length() && i < end - 1; i++) {
+		for (int i = 0; i < line.length(); i++) {
 			char c = line.charAt(i);
 
 			appendRespectingTab(codeLine, c, c);
-			appendRespectingTab(noteLine, c, '^');
+
+			if (i < end - 1) {
+				appendRespectingTab(noteLine, c, '^');
+			}
 		}
 
 		builder.append(codeLine).append("\n").append(noteLine);

--- a/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
@@ -11,10 +11,13 @@ public record SourceSpan(
 	int startOffset,
 	int endOffset
 ) {
-
 	public SourceSpan {
 		if (startOffset > endOffset) {
 			throw new IllegalArgumentException("start must not be later than end");
 		}
+	}
+
+	public static SourceSpan dummy() {
+		return new SourceSpan(0, 0);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/SourceSpan.java
@@ -1,5 +1,8 @@
 package com.github.firmwehr.gentle.source;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /**
  * A contiguous section of the source code file that extends from the character at {@code startOffset} to the character
  * at {@code endOffset - 1}.
@@ -15,6 +18,22 @@ public record SourceSpan(
 		if (startOffset > endOffset) {
 			throw new IllegalArgumentException("start must not be later than end");
 		}
+	}
+
+	public static SourceSpan from(SourceSpan span, Collection<SourceSpan> spans) {
+		int start = span.startOffset;
+		int end = span.endOffset;
+
+		for (SourceSpan sourceSpan : spans) {
+			start = Math.min(start, sourceSpan.startOffset);
+			end = Math.max(end, sourceSpan.endOffset);
+		}
+
+		return new SourceSpan(start, end);
+	}
+
+	public static SourceSpan from(SourceSpan span, SourceSpan... spans) {
+		return from(span, Arrays.asList(spans));
 	}
 
 	public static SourceSpan dummy() {

--- a/src/main/java/com/github/firmwehr/gentle/util/Pair.java
+++ b/src/main/java/com/github/firmwehr/gentle/util/Pair.java
@@ -1,4 +1,7 @@
 package com.github.firmwehr.gentle.util;
 
-public record Pair<T, S>(T first, S second) {
+public record Pair<T, S>(
+	T first,
+	S second
+) {
 }

--- a/src/test/java/com/github/firmwehr/gentle/source/SourceTest.java
+++ b/src/test/java/com/github/firmwehr/gentle/source/SourceTest.java
@@ -10,98 +10,85 @@ class SourceTest {
 	void multipleLinuxLineEndings() {
 		Source source = new Source("Hello\n\nWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 2, 1));
+		assertThat(source.positionFromOffset(7)).isEqualTo(new SourcePosition(7, 3, 1));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 2, 1));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("");
-
-		assertThat(source.positionAndLineFromOffset(7).first()).isEqualTo(new SourcePosition(7, 3, 1));
-		assertThat(source.positionAndLineFromOffset(7).second()).isEqualTo("World");
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("");
+		assertThat(source.getLine(3)).isEqualTo("World");
 	}
 
 	@Test
 	void multipleWindowsLineEndings() {
 		Source source = new Source("Hello\r\n\r\nWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 1, 7));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 1, 7));
 
-		assertThat(source.positionAndLineFromOffset(7).first()).isEqualTo(new SourcePosition(7, 2, 1));
-		assertThat(source.positionAndLineFromOffset(7).second()).isEqualTo("");
-		assertThat(source.positionAndLineFromOffset(8).first()).isEqualTo(new SourcePosition(8, 2, 2));
-		assertThat(source.positionAndLineFromOffset(8).second()).isEqualTo("");
+		assertThat(source.positionFromOffset(7)).isEqualTo(new SourcePosition(7, 2, 1));
+		assertThat(source.positionFromOffset(8)).isEqualTo(new SourcePosition(8, 2, 2));
 
-		assertThat(source.positionAndLineFromOffset(9).first()).isEqualTo(new SourcePosition(9, 3, 1));
-		assertThat(source.positionAndLineFromOffset(9).second()).isEqualTo("World");
+		assertThat(source.positionFromOffset(9)).isEqualTo(new SourcePosition(9, 3, 1));
+
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("");
+		assertThat(source.getLine(3)).isEqualTo("World");
 	}
 
 	@Test
 	void multipleMacLineEndings() {
 		Source source = new Source("Hello\r\rWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 2, 1));
+		assertThat(source.positionFromOffset(7)).isEqualTo(new SourcePosition(7, 3, 1));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 2, 1));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("");
-
-		assertThat(source.positionAndLineFromOffset(7).first()).isEqualTo(new SourcePosition(7, 3, 1));
-		assertThat(source.positionAndLineFromOffset(7).second()).isEqualTo("World");
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("");
+		assertThat(source.getLine(3)).isEqualTo("World");
 	}
 
 	@Test
 	void linuxLineEndings() {
 		Source source = new Source("Hello\nWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 2, 1));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 2, 1));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("World");
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("World");
 	}
 
 	@Test
 	void windowsLineEndings() {
 		Source source = new Source("Hello\r\nWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 1, 7));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 1, 7));
 
-		assertThat(source.positionAndLineFromOffset(7).first()).isEqualTo(new SourcePosition(7, 2, 1));
-		assertThat(source.positionAndLineFromOffset(7).second()).isEqualTo("World");
+		assertThat(source.positionFromOffset(7)).isEqualTo(new SourcePosition(7, 2, 1));
+
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("World");
 	}
 
 	@Test
 	void macLineEndings() {
 		Source source = new Source("Hello\rWorld");
 
-		assertThat(source.positionAndLineFromOffset(3).first()).isEqualTo(new SourcePosition(3, 1, 4));
-		assertThat(source.positionAndLineFromOffset(3).second()).isEqualTo("Hello");
+		assertThat(source.positionFromOffset(3)).isEqualTo(new SourcePosition(3, 1, 4));
+		assertThat(source.positionFromOffset(5)).isEqualTo(new SourcePosition(5, 1, 6));
+		assertThat(source.positionFromOffset(6)).isEqualTo(new SourcePosition(6, 2, 1));
 
-		assertThat(source.positionAndLineFromOffset(5).first()).isEqualTo(new SourcePosition(5, 1, 6));
-		assertThat(source.positionAndLineFromOffset(5).second()).isEqualTo("Hello");
-
-		assertThat(source.positionAndLineFromOffset(6).first()).isEqualTo(new SourcePosition(6, 2, 1));
-		assertThat(source.positionAndLineFromOffset(6).second()).isEqualTo("World");
+		assertThat(source.getLine(1)).isEqualTo("Hello");
+		assertThat(source.getLine(2)).isEqualTo("World");
 	}
 }


### PR DESCRIPTION
- [x] Extract type conversion helper
- [x] Check types
- [x] Check for side effects in expression statements
- [x] Check assignment lvalues
- [x] Check for return on every path
- [x] Find and check main method
- [x] Better SourceSpan-based error messages (for expressions)
- [x] SemanticException variant with no SourceSpan (e. g. for missing main method)
- [x] Don't pass any `null`s to SemanticExceptions
- [x] Update local variable list after creating method body
- [x] Fix array type assignability
- [x] Fix findMainMethod return value (maybe ignore it?)
- [x] Implement `--check` flag (Blatt 5)
- [x] Rename unused variables to `ignore`
- [x] Weaken "class could be a record" warning
- [x] Make qodana happy
- [x] Resolve all TODO and FIXME comments
- [x] Recognize `System` functions