### PR TITLE
Replace omitParentheses boolean

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/ClassDeclaration.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/ClassDeclaration.java
@@ -34,7 +34,7 @@ public record ClassDeclaration(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		List<Field> fields = this.fields.stream()
 			.sorted(Comparator.comparing(field -> field.name().ident()))
 			.collect(Collectors.toList());

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Field.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Field.java
@@ -8,7 +8,7 @@ public record Field(
 	Ident name
 ) implements PrettyPrint {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("public ").add(type).add(" ").add(name).add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Ident.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Ident.java
@@ -21,7 +21,7 @@ public record Ident(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(ident);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/MainMethod.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/MainMethod.java
@@ -22,7 +22,7 @@ public record MainMethod(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("public static void ").add(name).add("(").add(parameter).add(") ").add(body);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Method.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Method.java
@@ -32,7 +32,7 @@ public record Method(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("public ")
 			.add(returnType)
 			.add(" ")

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Parameter.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Parameter.java
@@ -8,7 +8,7 @@ public record Parameter(
 	Ident name
 ) implements PrettyPrint {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(type).add(" ").add(name);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Program.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Program.java
@@ -18,7 +18,7 @@ public record Program(List<ClassDeclaration> classes) implements PrettyPrint {
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		List<ClassDeclaration> classes =
 			this.classes.stream().sorted(Comparator.comparing(c -> c.name().ident())).collect(Collectors.toList());
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/Type.java
@@ -40,7 +40,7 @@ public record Type(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(basicType);
 		for (int i = 0; i < arrayLevel; i++) {
 			p.add("[]");

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BooleanType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/BooleanType.java
@@ -5,7 +5,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record BooleanType(SourceSpan sourceSpan) implements BasicType {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("boolean");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IdentType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IdentType.java
@@ -6,7 +6,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record IdentType(Ident name) implements BasicType {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(name);
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IntType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/IntType.java
@@ -5,7 +5,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record IntType(SourceSpan sourceSpan) implements BasicType {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("int");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/VoidType.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/basictype/VoidType.java
@@ -5,7 +5,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record VoidType(SourceSpan sourceSpan) implements BasicType {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("void");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ArrayAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ArrayAccessExpression.java
@@ -9,14 +9,14 @@ public record ArrayAccessExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
-		p.add(expression).add("[").add(index, true).add("]");
+		p.add(expression).add("[").add(index, Parentheses.OMIT).add("]");
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BinaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BinaryOperatorExpression.java
@@ -10,14 +10,14 @@ public record BinaryOperatorExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
 		p.add(lhs).add(" ").add(operator.getName()).add(" ").add(rhs);
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BooleanLiteralExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/BooleanLiteralExpression.java
@@ -8,7 +8,7 @@ public record BooleanLiteralExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		if (value) {
 			p.add("true");
 		} else {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/FieldAccessExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/FieldAccessExpression.java
@@ -10,14 +10,14 @@ public record FieldAccessExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
 		p.add(expression).add(".").add(name);
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IdentExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IdentExpression.java
@@ -6,7 +6,7 @@ import com.github.firmwehr.gentle.source.SourceSpan;
 
 public record IdentExpression(Ident name) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(name);
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IntegerLiteralExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/IntegerLiteralExpression.java
@@ -10,7 +10,7 @@ public record IntegerLiteralExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(value.toString());
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/LocalMethodCallExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/LocalMethodCallExpression.java
@@ -12,14 +12,14 @@ public record LocalMethodCallExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
-		p.add(name).add("(").addAll(arguments, ", ", false, true).add(")");
+		p.add(name).add("(").addAll(arguments, ", ", false, Parentheses.OMIT).add(")");
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/MethodInvocationExpression.java
@@ -14,14 +14,14 @@ public record MethodInvocationExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
-		p.add(expression).add(".").add(name).add("(").addAll(arguments, ", ", false, true).add(")");
+		p.add(expression).add(".").add(name).add("(").addAll(arguments, ", ", false, Parentheses.OMIT).add(")");
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewArrayExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewArrayExpression.java
@@ -15,17 +15,17 @@ public record NewArrayExpression(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
-		p.add("new ").add(type.basicType()).add("[").add(size, true).add("]");
+		p.add("new ").add(type.basicType()).add("[").add(size, Parentheses.OMIT).add("]");
 		for (int i = 0; i < type.arrayLevel() - 1; i++) {
 			p.add("[]");
 		}
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewObjectExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NewObjectExpression.java
@@ -9,14 +9,14 @@ public record NewObjectExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
 		p.add("new ").add(name).add("()");
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NullExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/NullExpression.java
@@ -7,7 +7,7 @@ public record NullExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("null");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ThisExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/ThisExpression.java
@@ -7,7 +7,7 @@ public record ThisExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("this");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/UnaryOperatorExpression.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/expression/UnaryOperatorExpression.java
@@ -10,14 +10,14 @@ public record UnaryOperatorExpression(
 	SourceSpan sourceSpan
 ) implements Expression {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		if (!omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add("(");
 		}
 
 		p.add(operator.getName()).add(expression);
 
-		if (!omitParentheses) {
+		if (parens == Parentheses.INCLUDE) {
 			p.add(")");
 		}
 	}

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Block.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/Block.java
@@ -63,7 +63,7 @@ public record Block(List<BlockStatement> statements) implements Statement, Block
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		List<BlockStatement> statements =
 			this.statements.stream().filter(s -> !(s instanceof EmptyStatement)).collect(Collectors.toList());
 

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/EmptyStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/EmptyStatement.java
@@ -10,7 +10,7 @@ public record EmptyStatement() implements Statement, BlockStatement {
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ExpressionStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ExpressionStatement.java
@@ -10,7 +10,7 @@ public record ExpressionStatement(Expression expression) implements Statement, B
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		p.add(expression, true).add(";");
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		p.add(expression, Parentheses.OMIT).add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/IfStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/IfStatement.java
@@ -16,8 +16,8 @@ public record IfStatement(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		p.add("if (").add(condition, true).add(")");
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		p.add("if (").add(condition, Parentheses.OMIT).add(")");
 
 		boolean elseOnNewLine;
 		if (body instanceof EmptyStatement) {

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/LocalVariableDeclarationStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/LocalVariableDeclarationStatement.java
@@ -13,9 +13,9 @@ public record LocalVariableDeclarationStatement(
 	Optional<ExprWithParens> value
 ) implements BlockStatement {
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add(type).add(" ").add(name);
-		value.ifPresent(pair -> p.add(" = ").add(pair.expression(), true));
+		value.ifPresent(pair -> p.add(" = ").add(pair.expression(), Parentheses.OMIT));
 		p.add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ReturnStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/ReturnStatement.java
@@ -16,9 +16,9 @@ public record ReturnStatement(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
 		p.add("return");
-		returnValue.ifPresent(expression -> p.add(" ").add(expression, true));
+		returnValue.ifPresent(expression -> p.add(" ").add(expression, Parentheses.OMIT));
 		p.add(";");
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/WhileStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/WhileStatement.java
@@ -13,8 +13,8 @@ public record WhileStatement(
 	}
 
 	@Override
-	public void prettyPrint(PrettyPrinter p, boolean omitParentheses) {
-		p.add("while (").add(condition, true).add(")");
+	public void prettyPrint(PrettyPrinter p, Parentheses parens) {
+		p.add("while (").add(condition, Parentheses.OMIT).add(")");
 
 		if (body instanceof EmptyStatement) {
 			p.add(body);

--- a/src/main/java/com/github/firmwehr/gentle/parser/prettyprint/PrettyPrint.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/prettyprint/PrettyPrint.java
@@ -1,5 +1,10 @@
 package com.github.firmwehr.gentle.parser.prettyprint;
 
 public interface PrettyPrint {
-	void prettyPrint(PrettyPrinter p, boolean omitParentheses);
+	void prettyPrint(PrettyPrinter p, Parentheses parens);
+
+	enum Parentheses {
+		OMIT,
+		INCLUDE
+	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/parser/prettyprint/PrettyPrinter.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/prettyprint/PrettyPrinter.java
@@ -49,29 +49,29 @@ public class PrettyPrinter {
 		return this;
 	}
 
-	public <T extends PrettyPrint> PrettyPrinter add(T t, boolean omitParentheses) {
-		t.prettyPrint(this, omitParentheses);
+	public <T extends PrettyPrint> PrettyPrinter add(T t, PrettyPrint.Parentheses parens) {
+		t.prettyPrint(this, parens);
 
 		return this;
 	}
 
 	public <T extends PrettyPrint> PrettyPrinter add(T t) {
-		return add(t, false);
+		return add(t, PrettyPrint.Parentheses.INCLUDE);
 	}
 
 
 	public <T extends PrettyPrint> PrettyPrinter addAll(
-		List<T> ts, String separator, boolean newlines, boolean omitParentheses
+		List<T> ts, String separator, boolean newlines, PrettyPrint.Parentheses parens
 	) {
 		if (!ts.isEmpty()) {
 			for (int i = 0; i < ts.size() - 1; i++) {
-				add(ts.get(i), omitParentheses).add(separator);
+				add(ts.get(i), parens).add(separator);
 				if (newlines) {
 					newline();
 				}
 			}
 
-			add(ts.get(ts.size() - 1), omitParentheses);
+			add(ts.get(ts.size() - 1), parens);
 			if (newlines) {
 				newline();
 			}
@@ -81,7 +81,7 @@ public class PrettyPrinter {
 	}
 
 	public <T extends PrettyPrint> PrettyPrinter addAll(List<T> ts, String separator, boolean newlines) {
-		return addAll(ts, separator, newlines, true);
+		return addAll(ts, separator, newlines, PrettyPrint.Parentheses.OMIT);
 	}
 
 	public String format() {


### PR DESCRIPTION
Previously, the prettyprinting method would take a boolean value omitParentheses as an argument. This PR introduces refactors the argument into an enum.