### PR TITLE
Fix printing of empty statements as while loop body

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/WhileStatement.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/ast/statement/WhileStatement.java
@@ -17,7 +17,7 @@ public record WhileStatement(
 		p.add("while (").add(condition, Parentheses.OMIT).add(")");
 
 		if (body instanceof EmptyStatement) {
-			p.add(body);
+			p.add(" { }");
 		} else if (body instanceof Block) {
 			p.add(" ").add(body);
 		} else {


### PR DESCRIPTION
`while (true);` should be printed as `while (true) { }`, just like `if (true);` is printed as `if (true) { }`