### PR TITLE
Fix parsing of negative vs negated positive integer literals

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
+++ b/src/main/java/com/github/firmwehr/gentle/parser/Parser.java
@@ -374,6 +374,21 @@ public class Parser {
 				new UnaryOperatorExpression(UnaryOperator.LOGICAL_NOT, expression.expression(), span));
 		} else if (tokens.peek().isOperator(Operator.MINUS)) {
 			Token start = tokens.take();
+
+			// Special handling for negative integer literals
+			//
+			// "-3" is a single negative integer literal while "-(3)" is the negation of a positive integer literal.
+			// The AST has no way to represent parentheses, so without this special handling, the two cases become
+			// indistinguishable. This is a problem since "-2147483648" is a valid negative integer literal while
+			// "-(2147483648)" is the negation of an invalid positive integer literal and thus itself invalid.
+			expectingExpression();
+			Optional<IntegerLiteralToken> intLit = tokens.peek().asIntegerLiteralToken();
+			if (intLit.isPresent()) {
+				tokens.take();
+				SourceSpan span = SourceSpan.from(start.sourceSpan(), intLit.get().sourceSpan());
+				return new ExprWithParens(new IntegerLiteralExpression(intLit.get().value().negate(), span));
+			}
+
 			ExprWithParens expression = parseUnaryExpression();
 			SourceSpan span = SourceSpan.from(start.sourceSpan(), expression.parenSourceSpan());
 			return new ExprWithParens(

--- a/src/main/java/com/github/firmwehr/gentle/semantic/MethodScope.java
+++ b/src/main/java/com/github/firmwehr/gentle/semantic/MethodScope.java
@@ -15,7 +15,6 @@ import com.github.firmwehr.gentle.parser.ast.expression.NewArrayExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.NewObjectExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.NullExpression;
 import com.github.firmwehr.gentle.parser.ast.expression.ThisExpression;
-import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperatorExpression;
 import com.github.firmwehr.gentle.parser.ast.statement.Block;
 import com.github.firmwehr.gentle.parser.ast.statement.BlockStatement;
@@ -246,7 +245,9 @@ public record MethodScope(
 		try {
 			return new SIntegerValueExpression(expr.value().intValueExact(), expr.sourceSpan());
 		} catch (ArithmeticException e) {
-			throw new SemanticException(source, expr.sourceSpan(), "integer literal too large");
+			boolean negative = expr.value().signum() < 0;
+			String message = "integer literal too " + (negative ? "small" : "large");
+			throw new SemanticException(source, expr.sourceSpan(), message);
 		}
 	}
 
@@ -396,14 +397,6 @@ public record MethodScope(
 	}
 
 	SExpression convert(UnaryOperatorExpression expr) throws SemanticException {
-		if (expr.operator() == UnaryOperator.NEGATION && expr.expression() instanceof IntegerLiteralExpression i) {
-			try {
-				return new SIntegerValueExpression(i.value().negate().intValueExact(), expr.sourceSpan());
-			} catch (ArithmeticException e) {
-				throw new SemanticException(source, expr.sourceSpan(), "integer literal too small");
-			}
-		}
-
 		return new SUnaryOperatorExpression(expr.operator(), convert(expr.expression()), expr.sourceSpan());
 	}
 

--- a/src/test/java/com/github/firmwehr/gentle/parser/ParserTestCaseProvider.java
+++ b/src/test/java/com/github/firmwehr/gentle/parser/ParserTestCaseProvider.java
@@ -7,7 +7,6 @@ import com.github.firmwehr.gentle.parser.ast.Program;
 import com.github.firmwehr.gentle.parser.ast.Type;
 import com.github.firmwehr.gentle.parser.ast.expression.BinaryOperator;
 import com.github.firmwehr.gentle.parser.ast.expression.Expression;
-import com.github.firmwehr.gentle.parser.ast.expression.UnaryOperator;
 import com.github.firmwehr.gentle.parser.ast.statement.Statement;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -361,7 +360,7 @@ public class ParserTestCaseProvider implements ArgumentsProvider {
 								.thenReturn(Expression.newCall(
 									"clamp",
 									Expression.newIdent("n"),
-									Expression.newInt(1).withUnary(UnaryOperator.NEGATION),
+									Expression.newInt(-1),
 									Expression.newInt(1)
 								))))
 						.withMethod(Method.dummy("sum")


### PR DESCRIPTION
`-3` is a negative integer literal while `-(3)` is a negated positive integer literal. This means that `-2147483648` is valid while `-(2147483648)` is invalid.

Bug discovered thanks to Group 3's test `LargeNegativeIntegerLiteral.invalid.mj`.