### PR TITLE
Fix error messages

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -51,25 +51,33 @@ public class GentleCompiler {
 			flagsSet.add("check");
 		}
 
-		if (flagsSet.isEmpty()) {
-			UserOutput.userError("No operation specified.");
-			System.exit(1);
-		} else if (flagsSet.size() != 1) {
-			UserOutput.userError("Conflicting flags set. Received the following mutually exclusive flags: " + flagsSet);
-			System.exit(1);
-		} else if (arguments.echo()) {
-			echoCommand(arguments.path());
-		} else if (arguments.lextest()) {
-			lexTestCommand(arguments.path());
-		} else if (arguments.parsetest()) {
-			parseTestCommand(arguments.path());
-		} else if (arguments.printAst()) {
-			printAstCommand(arguments.path());
-		} else if (arguments.check()) {
-			checkCommand(arguments.path());
-		} else {
-			// This can never be reached
-			runCommand(arguments.path());
+		try {
+			if (flagsSet.isEmpty()) {
+				UserOutput.userError("No operation specified.");
+				System.exit(1);
+			} else if (flagsSet.size() != 1) {
+				UserOutput.userError(
+					"Conflicting flags set. Received the following mutually exclusive flags: " + flagsSet);
+				System.exit(1);
+			} else if (arguments.echo()) {
+				echoCommand(arguments.path());
+			} else if (arguments.lextest()) {
+				lexTestCommand(arguments.path());
+			} else if (arguments.parsetest()) {
+				parseTestCommand(arguments.path());
+			} else if (arguments.printAst()) {
+				printAstCommand(arguments.path());
+			} else if (arguments.check()) {
+				checkCommand(arguments.path());
+			} else {
+				// This can never be reached
+				runCommand(arguments.path());
+			}
+		} catch (Exception e) {
+			UserOutput.userMessage("something went wrong, pls annoy me mjtest");
+			UserOutput.outputMessage(e.toString());
+			//noinspection UseOfSystemOutOrSystemErr
+			e.printStackTrace(System.out);
 		}
 
 		System.exit(0);

--- a/src/main/java/com/github/firmwehr/gentle/source/Source.java
+++ b/src/main/java/com/github/firmwehr/gentle/source/Source.java
@@ -2,6 +2,7 @@ package com.github.firmwehr.gentle.source;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.fusesource.jansi.Ansi.ansi;
 
@@ -105,7 +106,10 @@ public record Source(String content) {
 	}
 
 	private List<String> getLines(int startRow, int amount) {
-		return content.lines().skip(startRow - 1).limit(amount).collect(Collectors.toList());
+		return Stream.concat(content.lines(), Stream.generate(() -> ""))
+			.skip(startRow - 1)
+			.limit(amount)
+			.collect(Collectors.toList());
 	}
 
 	public String formatMessageAt(SourceSpan span, String message) {


### PR DESCRIPTION
Fixes crash when trying to format error message for a file containing only `/*`. This PR also makes mjtest fail a test if an unexpected exception occurs.