### PR TITLE
Fix wrong assumption in constant folding

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
@@ -38,6 +38,12 @@ public interface CommandArguments {
 	@Option(names = "--dump-graphs", description = "generate graph dump files")
 	boolean dumpGraphs();
 
+	@Option(names = "--no-constant-folding", description = "do not perform constant folding optimization")
+	boolean noConstantFolding();
+
+	@Option(names = "--no-arithmetic-optimization", description = "do not perform arithmetic optimizations")
+	boolean noArithmeticOptimizations();
+
 	@Parameter(index = 0, converter = ExistingFileConverter.class, description = "file to read and operate on",
 		paramLabel = "FILE")
 	Path path();

--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
@@ -7,6 +7,8 @@ import com.github.firmwehr.gentle.semantic.ast.SProgram;
 import firm.Backend;
 import firm.DebugInfo;
 import firm.Firm;
+import firm.Graph;
+import firm.Program;
 import firm.Util;
 
 import java.io.IOException;
@@ -14,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.EnumSet;
 
+import static com.github.firmwehr.gentle.util.GraphDumper.dumpGraph;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -57,6 +60,9 @@ public class FirmBuilder {
 
 		// Lower "Member"
 		Util.lowerSels();
+		for (Graph graph : Program.getGraphs()) {
+			dumpGraph(graph, "lower-sel");
+		}
 
 		if (!CompilerArguments.get().noConstantFolding()) {
 			ConstantFolding.optimize();

--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
@@ -1,5 +1,7 @@
 package com.github.firmwehr.gentle.firm.construction;
 
+import com.github.firmwehr.gentle.cli.CompilerArguments;
+import com.github.firmwehr.gentle.firm.optimization.ArithmeticOptimization;
 import com.github.firmwehr.gentle.firm.optimization.ConstantFolding;
 import com.github.firmwehr.gentle.semantic.ast.SProgram;
 import firm.Backend;
@@ -56,7 +58,12 @@ public class FirmBuilder {
 		// Lower "Member"
 		Util.lowerSels();
 
-		ConstantFolding.optimize();
+		if (!CompilerArguments.get().noConstantFolding()) {
+			ConstantFolding.optimize();
+		}
+		if (!CompilerArguments.get().noArithmeticOptimizations()) {
+			ArithmeticOptimization.optimize();
+		}
 
 		String assemblyFile = assemblyOutputFile.toAbsolutePath().toString();
 		Backend.createAssembler(assemblyFile, assemblyFile);

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ArithmeticOptimization.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ArithmeticOptimization.java
@@ -1,0 +1,173 @@
+package com.github.firmwehr.gentle.firm.optimization;
+
+import com.github.firmwehr.gentle.output.Logger;
+import firm.BackEdges;
+import firm.Graph;
+import firm.Mode;
+import firm.Program;
+import firm.TargetValue;
+import firm.bindings.binding_irgopt;
+import firm.nodes.Add;
+import firm.nodes.Const;
+import firm.nodes.Div;
+import firm.nodes.Mul;
+import firm.nodes.Node;
+import firm.nodes.NodeVisitor;
+import firm.nodes.Sub;
+
+import static com.github.firmwehr.gentle.util.GraphDumper.dumpGraph;
+
+public class ArithmeticOptimization extends NodeVisitor.Default {
+
+	private static final Logger LOGGER = new Logger(ArithmeticOptimization.class);
+
+	private boolean hasChanged;
+	private final Graph graph;
+
+	public ArithmeticOptimization(Graph graph) {
+		this.graph = graph;
+	}
+
+	public static void optimize() {
+		LOGGER.info("Started");
+		for (Graph graph : Program.getGraphs()) {
+			LOGGER.info("Running constant folding for %s", graph);
+
+			while (true) {
+				// Needs to be done in each iteration apparently?
+				BackEdges.enable(graph);
+
+				ArithmeticOptimization arithmeticOptimization = new ArithmeticOptimization(graph);
+				arithmeticOptimization.applyArithmeticOptimization();
+				binding_irgopt.remove_bads(graph.ptr);
+				binding_irgopt.remove_unreachable_code(graph.ptr);
+
+				// testing has shown that back edges get disabled anyway for some reason, but we don't like problems
+				BackEdges.disable(graph);
+
+				if (!arithmeticOptimization.hasChanged) {
+					break;
+				}
+			}
+			dumpGraph(graph, "arithmetic");
+		}
+		LOGGER.info("Finished");
+	}
+
+	private void applyArithmeticOptimization() {
+		LOGGER.debugHeader("Analyzing");
+		graph.walkTopological(this);
+	}
+
+	@Override
+	public void visit(Add node) {
+		if (tarValOf(node.getRight()).isNull()) {
+			exchange(node, node.getLeft());
+			return;
+		}
+		if (tarValOf(node.getLeft()).isNull()) {
+			exchange(node, node.getRight());
+		}
+	}
+
+	@Override
+	public void visit(Sub node) {
+		TargetValue leftVal = tarValOf(node.getLeft());
+		TargetValue rightVal = tarValOf(node.getRight());
+
+		if (rightVal.isNull()) {
+			exchange(node, node.getLeft());
+			return;
+		}
+		if (leftVal.isNull()) {
+			exchange(node, node.getGraph().newMinus(node.getBlock(), node.getRight()));
+			return;
+		}
+		if (leftVal.isConstant() && leftVal.equals(rightVal)) {
+			exchange(node, node.getGraph().newConst(0, node.getLeft().getMode()));
+		}
+	}
+
+	@Override
+	public void visit(Mul node) {
+		TargetValue leftVal = tarValOf(node.getLeft());
+		TargetValue rightVal = tarValOf(node.getRight());
+
+		// some algebraic identities
+		// 1 * a => a
+		if (leftVal.isOne()) {
+			exchange(node, node.getRight());
+			return;
+		}
+		// a * 1 => a
+		if (rightVal.isOne()) {
+			exchange(node, node.getLeft());
+			return;
+		}
+		// 0 * a => 0 && a * 0 => 0
+		if (leftVal.isNull() || rightVal.isNull()) {
+			exchange(node, node.getGraph().newConst(0, node.getLeft().getMode()));
+			return;
+		}
+		// a * -1 => -a
+		if (rightVal.isConstant() && rightVal.isNegative() && rightVal.abs().isOne()) {
+			exchange(node, node.getGraph().newMinus(node.getBlock(), node.getLeft()));
+			return;
+		}
+		// -1 * a => -a
+		if (leftVal.isConstant() && leftVal.isNegative() && leftVal.abs().isOne()) {
+			exchange(node, node.getGraph().newMinus(node.getBlock(), node.getRight()));
+		}
+		// TODO (maybe): 2 * a => a << 2
+	}
+
+	@Override
+	public void visit(Div node) {
+		TargetValue rightVal = tarValOf(node.getRight());
+		// a / 1 => a
+		if (rightVal.isOne()) {
+			replace(node, node.getMem(), node.getLeft());
+			return;
+		}
+		// a / -1 => -a
+		if (rightVal.isConstant() && rightVal.abs().isOne() && rightVal.isNegative()) {
+			replace(node, node.getMem(), node.getGraph().newMinus(node.getBlock(), node.getLeft()));
+		}
+	}
+
+	private void exchange(Node victim, Node murderer) {
+		Graph.exchange(victim, murderer);
+		hasChanged = true;
+	}
+
+	/**
+	 * <pre>
+	 * 	  Div
+	 * 	 /   \
+	 * 	M    Res
+	 * </pre>
+	 * Mod and Div have side effects on memory, we can't just replace them like everything else. Instead, we need to
+	 * rewire their memory and output projections.
+	 *
+	 * @param node the div/mod node to replace
+	 * @param previousMemory the memory input of the node
+	 * @param replacement the replacement (maybe constant) node
+	 */
+	private void replace(Node node, Node previousMemory, Node replacement) {
+		for (BackEdges.Edge out : BackEdges.getOuts(node)) {
+			if (out.node.getMode().equals(Mode.getM())) {
+				Graph.exchange(out.node, previousMemory);
+			} else {
+				Graph.exchange(out.node, replacement);
+			}
+		}
+	}
+
+	private TargetValue tarValOf(Node node) {
+		if (node instanceof Const constant) {
+			return constant.getTarval();
+		}
+
+		return TargetValue.getBad();
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ArithmeticOptimization.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ArithmeticOptimization.java
@@ -31,7 +31,7 @@ public class ArithmeticOptimization extends NodeVisitor.Default {
 	public static void optimize() {
 		LOGGER.info("Started");
 		for (Graph graph : Program.getGraphs()) {
-			LOGGER.info("Running constant folding for %s", graph);
+			LOGGER.info("Running arithmetic optimization for %s", graph);
 
 			while (true) {
 				// Needs to be done in each iteration apparently?
@@ -47,6 +47,8 @@ public class ArithmeticOptimization extends NodeVisitor.Default {
 
 				if (!arithmeticOptimization.hasChanged) {
 					break;
+				} else if (LOGGER.isDebugEnabled()) {
+					dumpGraph(graph, "arithmetic-iteration");
 				}
 			}
 			dumpGraph(graph, "arithmetic");

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
@@ -11,35 +11,47 @@ import firm.TargetValue;
 import firm.bindings.binding_irgopt;
 import firm.bindings.binding_irnode;
 import firm.nodes.Add;
+import firm.nodes.Address;
+import firm.nodes.Align;
 import firm.nodes.And;
 import firm.nodes.Bad;
 import firm.nodes.Binop;
+import firm.nodes.Bitcast;
 import firm.nodes.Block;
 import firm.nodes.Call;
 import firm.nodes.Cmp;
 import firm.nodes.Cond;
+import firm.nodes.Confirm;
 import firm.nodes.Const;
 import firm.nodes.Conv;
 import firm.nodes.Div;
+import firm.nodes.Dummy;
+import firm.nodes.Eor;
 import firm.nodes.Id;
+import firm.nodes.Jmp;
+import firm.nodes.Load;
 import firm.nodes.Member;
 import firm.nodes.Minus;
 import firm.nodes.Mod;
 import firm.nodes.Mul;
+import firm.nodes.Mulh;
+import firm.nodes.NoMem;
 import firm.nodes.Node;
 import firm.nodes.NodeVisitor;
 import firm.nodes.Not;
+import firm.nodes.Offset;
 import firm.nodes.Or;
 import firm.nodes.Phi;
 import firm.nodes.Proj;
 import firm.nodes.Return;
-import firm.nodes.Sel;
 import firm.nodes.Shl;
 import firm.nodes.Shr;
 import firm.nodes.Shrs;
 import firm.nodes.Size;
 import firm.nodes.Start;
+import firm.nodes.Store;
 import firm.nodes.Sub;
+import firm.nodes.Unknown;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -407,16 +419,16 @@ public class ConstantFolding extends NodeVisitor.Default {
 
 	@Override
 	public void visit(Proj node) {
+		// Some nodes (like Div) have multiple outgoing projections. If the Div is constant, we do not want to replace
+		// the memory output node with the Div constant - that makes no sense!
+		if (node.getMode().equals(Mode.getM())) {
+			return;
+		}
 		updateTarVal(node, tarValOf(node.getPred()));
 	}
 
 	@Override
 	public void visit(Return node) {
-	}
-
-	@Override
-	public void visit(Sel node) {
-		// TODO: Fold unchanged array values?
 	}
 
 	@Override
@@ -494,16 +506,56 @@ public class ConstantFolding extends NodeVisitor.Default {
 		return op.apply(first, second);
 	}
 
+	@SuppressWarnings("DuplicateBranchesInSwitch")
 	private TargetValue tarValOf(Node node) {
-		return constants.computeIfAbsent(node, ignored -> {
-			if (node instanceof Call) {
-				return TargetValue.getBad();
-			}
-			if (node instanceof Start) {
-				return TargetValue.getBad();
-			}
+		return constants.computeIfAbsent(node, ignore -> {
+			// Welcome to Whack-A-Mole! Compilerpraktkum Edition 2021 (Corona Release)
+			// Highscores:
+			//    Chris   : 4
+			//    Istannen: 4
+			// Please enter your score: __
 
-			return TargetValue.getUnknown();
+			return switch (node) {
+				case Add ignored -> TargetValue.getUnknown();
+				case Address ignored -> TargetValue.getUnknown();
+				case Align ignored -> TargetValue.getUnknown();
+				case And ignored -> TargetValue.getUnknown();
+				case Bad ignored -> TargetValue.getBad();
+				case Bitcast ignored -> TargetValue.getUnknown();
+				case Call ignored -> TargetValue.getBad();
+				case Cmp ignored -> TargetValue.getUnknown();
+				case Cond ignored -> TargetValue.getUnknown();
+				case Confirm ignored -> TargetValue.getUnknown();
+				case Const ignored -> TargetValue.getUnknown();
+				case Conv ignored -> TargetValue.getUnknown();
+				case Div ignored -> TargetValue.getUnknown();
+				case Dummy ignored -> TargetValue.getUnknown();
+				case Eor ignored -> TargetValue.getUnknown();
+				case Id id -> tarValOf(id.getPred());
+				case Jmp ignored -> TargetValue.getUnknown();
+				case Load ignored -> TargetValue.getBad();
+				case Member ignored -> TargetValue.getBad();
+				case Minus ignored -> TargetValue.getUnknown();
+				case Mod ignored -> TargetValue.getUnknown();
+				case Mul ignored -> TargetValue.getUnknown();
+				case Mulh ignored -> TargetValue.getUnknown();
+				case NoMem ignored -> TargetValue.getUnknown();
+				case Not ignored -> TargetValue.getUnknown();
+				case Offset ignored -> TargetValue.getUnknown();
+				case Or ignored -> TargetValue.getUnknown();
+				case Phi ignored -> TargetValue.getUnknown();
+				case Proj ignored -> TargetValue.getUnknown();
+				case Shl ignored -> TargetValue.getUnknown();
+				case Shr ignored -> TargetValue.getUnknown();
+				case Shrs ignored -> TargetValue.getUnknown();
+				case Size ignored -> TargetValue.getUnknown();
+				case Start ignored -> TargetValue.getBad();
+				case Store ignored -> TargetValue.getBad();
+				case Sub ignored -> TargetValue.getUnknown();
+				case Unknown ignored -> TargetValue.getUnknown();
+				default -> throw new InternalCompilerException(
+					"Unknown node type, can not determine constant folding default value");
+			};
 		});
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
@@ -15,6 +15,7 @@ import firm.nodes.And;
 import firm.nodes.Bad;
 import firm.nodes.Binop;
 import firm.nodes.Block;
+import firm.nodes.Call;
 import firm.nodes.Cmp;
 import firm.nodes.Cond;
 import firm.nodes.Const;
@@ -37,6 +38,7 @@ import firm.nodes.Shl;
 import firm.nodes.Shr;
 import firm.nodes.Shrs;
 import firm.nodes.Size;
+import firm.nodes.Start;
 import firm.nodes.Sub;
 
 import java.util.ArrayDeque;
@@ -493,7 +495,16 @@ public class ConstantFolding extends NodeVisitor.Default {
 	}
 
 	private TargetValue tarValOf(Node node) {
-		return constants.getOrDefault(node, TargetValue.getUnknown());
+		return constants.computeIfAbsent(node, ignored -> {
+			if (node instanceof Call) {
+				return TargetValue.getBad();
+			}
+			if (node instanceof Start) {
+				return TargetValue.getBad();
+			}
+
+			return TargetValue.getUnknown();
+		});
 	}
 
 	private static String debugTarVal(TargetValue targetValue) {


### PR DESCRIPTION
## Problem
Before this patch, all nodes were assigned a `⊥` value. This is incorrect, as you can't just assume loaded values or arguments have a single value - their value might change at every load. 

## Changes
* Add a mapping from node to `⊤` or `⊥`
* Move arithmetic optimizations to their own class
* Add CLI switches to disable constant folding / arithmetic optimizations