### PR TITLE
Convert constant to correct mode in arithmetic optimization

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmGraphBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmGraphBuilder.java
@@ -307,7 +307,8 @@ public class FirmGraphBuilder {
 			case DIVIDE -> {
 				Node lhs = processValueExpression(context, expr.lhs());
 				Node rhs = processValueExpression(context, expr.rhs());
-				// expansion to 64 bit to gracefully handle MIN_INT / -1 case which is valid in Java but causes floating point exception (sic) on x86
+				// expansion to 64 bit to gracefully handle MIN_INT / -1 case which is valid in Java but causes
+				// floating point exception (sic) on x86
 				Node leftPromoted = construction.newConv(lhs, Mode.getLs());
 				Node rightPromoted = construction.newConv(rhs, Mode.getLs());
 

--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/TypeHelper.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/TypeHelper.java
@@ -33,7 +33,7 @@ public class TypeHelper {
 	private final Map<SClassDeclaration, PointerType> classTypes;
 
 	public TypeHelper() {
-		this.stringType = new ClassType("String");
+		this.stringType = new PointerType(new ClassType("String"));
 		this.classTypes = new HashMap<>();
 		this.voidType = new PrimitiveType(Mode.getANY());
 	}

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
@@ -65,7 +65,7 @@ import java.util.stream.StreamSupport;
 import static com.github.firmwehr.gentle.util.GraphDumper.dumpGraph;
 
 public class ConstantFolding extends NodeVisitor.Default {
-	private static final Logger LOGGER = new Logger(ConstantFolding.class, Logger.LogLevel.DEBUG);
+	private static final Logger LOGGER = new Logger(ConstantFolding.class);
 
 	private final Graph graph;
 	// stores associated lattice element for each visited note during fixed point iteration


### PR DESCRIPTION
This fixes an issue with e.g.:

```java
class Foo {
  public int a;
  public int b;

  public void trigger() {
    public Foo f = null;
    f.b = 20; /* needs to be the *second* field in the struct so an offset ADD is generated */
  }
}
```