### PR TITLE
Make optimizations more flexible

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
@@ -3,6 +3,7 @@ package com.github.firmwehr.gentle.firm.construction;
 import com.github.firmwehr.gentle.cli.CompilerArguments;
 import com.github.firmwehr.gentle.firm.optimization.ArithmeticOptimization;
 import com.github.firmwehr.gentle.firm.optimization.ConstantFolding;
+import com.github.firmwehr.gentle.firm.optimization.Optimizer;
 import com.github.firmwehr.gentle.semantic.ast.SProgram;
 import firm.Backend;
 import firm.DebugInfo;
@@ -64,12 +65,16 @@ public class FirmBuilder {
 			dumpGraph(graph, "lower-sel");
 		}
 
+		Optimizer.Builder builder = Optimizer.builder();
+
 		if (!CompilerArguments.get().noConstantFolding()) {
-			ConstantFolding.optimize();
+			builder.addStep(ConstantFolding.constantFolding());
 		}
 		if (!CompilerArguments.get().noArithmeticOptimizations()) {
-			ArithmeticOptimization.optimize();
+			builder.addStep(ArithmeticOptimization.arithmeticOptimization());
 		}
+		Optimizer optimizer = builder.build();
+		optimizer.optimize();
 
 		String assemblyFile = assemblyOutputFile.toAbsolutePath().toString();
 		Backend.createAssembler(assemblyFile, assemblyFile);

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/GraphOptimizationStep.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/GraphOptimizationStep.java
@@ -4,14 +4,12 @@ import com.github.firmwehr.gentle.output.Logger;
 import com.google.common.base.Preconditions;
 import firm.Graph;
 
-import java.util.function.Predicate;
-
-public final class GraphOptimizationStep implements Predicate<Graph> {
+public final class GraphOptimizationStep {
 	private static final Logger LOGGER = new Logger(GraphOptimizationStep.class);
-	private String description;
-	private Predicate<Graph> optimizationFunction;
+	private final String description;
+	private final OptimizationFunction optimizationFunction;
 
-	private GraphOptimizationStep(String description, Predicate<Graph> optimizationFunction) {
+	private GraphOptimizationStep(String description, OptimizationFunction optimizationFunction) {
 		this.description = description;
 		this.optimizationFunction = optimizationFunction;
 	}
@@ -19,28 +17,23 @@ public final class GraphOptimizationStep implements Predicate<Graph> {
 
 	public boolean optimize(Graph graph) {
 		LOGGER.info("Running %s for %s", this.description, graph);
-		return this.optimizationFunction.test(graph);
-	}
-
-	@Override
-	public boolean test(Graph graph) {
-		return optimize(graph);
+		return this.optimizationFunction.optimize(graph);
 	}
 
 	public static Builder builder() {
 		return new Builder();
 	}
 
-	static class Builder {
+	public static class Builder {
 		private String description;
-		private Predicate<Graph> optimizationFunction;
+		private OptimizationFunction optimizationFunction;
 
 		public Builder withDescription(String description) {
 			this.description = description;
 			return this;
 		}
 
-		public Builder withOptimizationFunction(Predicate<Graph> optimizationFunction) {
+		public Builder withOptimizationFunction(OptimizationFunction optimizationFunction) {
 			this.optimizationFunction = optimizationFunction;
 			return this;
 		}
@@ -50,5 +43,11 @@ public final class GraphOptimizationStep implements Predicate<Graph> {
 			Preconditions.checkState(this.optimizationFunction != null, "Optimization Function must be set");
 			return new GraphOptimizationStep(this.description, this.optimizationFunction);
 		}
+	}
+
+	@FunctionalInterface
+	public interface OptimizationFunction {
+
+		boolean optimize(Graph graph);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/GraphOptimizationStep.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/GraphOptimizationStep.java
@@ -1,0 +1,54 @@
+package com.github.firmwehr.gentle.firm.optimization;
+
+import com.github.firmwehr.gentle.output.Logger;
+import com.google.common.base.Preconditions;
+import firm.Graph;
+
+import java.util.function.Predicate;
+
+public final class GraphOptimizationStep implements Predicate<Graph> {
+	private static final Logger LOGGER = new Logger(GraphOptimizationStep.class);
+	private String description;
+	private Predicate<Graph> optimizationFunction;
+
+	private GraphOptimizationStep(String description, Predicate<Graph> optimizationFunction) {
+		this.description = description;
+		this.optimizationFunction = optimizationFunction;
+	}
+
+
+	public boolean optimize(Graph graph) {
+		LOGGER.info("Running %s for %s", this.description, graph);
+		return this.optimizationFunction.test(graph);
+	}
+
+	@Override
+	public boolean test(Graph graph) {
+		return optimize(graph);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	static class Builder {
+		private String description;
+		private Predicate<Graph> optimizationFunction;
+
+		public Builder withDescription(String description) {
+			this.description = description;
+			return this;
+		}
+
+		public Builder withOptimizationFunction(Predicate<Graph> optimizationFunction) {
+			this.optimizationFunction = optimizationFunction;
+			return this;
+		}
+
+		public GraphOptimizationStep build() {
+			Preconditions.checkState(this.description != null, "Description must be set");
+			Preconditions.checkState(this.optimizationFunction != null, "Optimization Function must be set");
+			return new GraphOptimizationStep(this.description, this.optimizationFunction);
+		}
+	}
+}

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/Optimizer.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/Optimizer.java
@@ -1,0 +1,46 @@
+package com.github.firmwehr.gentle.firm.optimization;
+
+
+import firm.Graph;
+import firm.Program;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Optimizer {
+	private final List<GraphOptimizationStep> graphOptimizationSteps;
+
+	private Optimizer(List<GraphOptimizationStep> graphOptimizationSteps) {
+		this.graphOptimizationSteps = List.copyOf(graphOptimizationSteps);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public void optimize() {
+		for (Graph graph : Program.getGraphs()) {
+			boolean changed;
+			do {
+				changed = false;
+				for (GraphOptimizationStep step : this.graphOptimizationSteps) {
+					changed |= step.optimize(graph);
+				}
+			} while (changed);
+		}
+	}
+
+
+	public static class Builder {
+		private final List<GraphOptimizationStep> graphOptimizationSteps = new ArrayList<>();
+
+		public Builder addStep(GraphOptimizationStep step) {
+			this.graphOptimizationSteps.add(step);
+			return this;
+		}
+
+		public Optimizer build() {
+			return new Optimizer(this.graphOptimizationSteps);
+		}
+	}
+}


### PR DESCRIPTION
With more optimizations coming, the "static optimize method" approach might be insufficient. For example, we want to re-run optimization a if optimization b changed the graph.

To do that, we apply optimizations per graph rather than applying each optimization on the whole program.