### PR TITLE
Exit with exit code 1 on error

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
+++ b/src/main/java/com/github/firmwehr/gentle/GentleCompiler.java
@@ -61,6 +61,7 @@ public class GentleCompiler {
 			UserOutput.outputMessage(e.toString());
 			//noinspection UseOfSystemOutOrSystemErr
 			e.printStackTrace(System.out);
+			System.exit(1);
 		}
 
 		System.exit(0);


### PR DESCRIPTION
Previously gentle exited with `0` if an error occurred. This hinders automated testing of compiler crashes.