### PR TITLE
Replace consecutive right shift, left shift instructions

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/backend/ir/codegen/CodeSelection.java
+++ b/src/main/java/com/github/firmwehr/gentle/backend/ir/codegen/CodeSelection.java
@@ -10,6 +10,7 @@ import com.github.firmwehr.gentle.backend.ir.IkeaUnassignedBøx;
 import com.github.firmwehr.gentle.backend.ir.IkeaVirtualRegister;
 import com.github.firmwehr.gentle.backend.ir.nodes.BoxScheme;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAdd;
+import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAnd;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaArgNode;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCall;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCmp;
@@ -42,6 +43,7 @@ import firm.Mode;
 import firm.Relation;
 import firm.nodes.Add;
 import firm.nodes.Address;
+import firm.nodes.And;
 import firm.nodes.Block;
 import firm.nodes.Call;
 import firm.nodes.Cmp;
@@ -174,6 +176,19 @@ public class CodeSelection extends NodeVisitor.Default {
 
 		IkeaBløck block = blocks.get((Block) node.getBlock());
 		IkeaAdd ikeaAdd = new IkeaAdd(nextRegister(node), nodes.get(node.getLeft()), nodes.get(node.getRight()), node);
+		nodes.put(node, ikeaAdd);
+		block.nodes().add(ikeaAdd);
+	}
+
+	@Override
+	public void visit(And node) {
+		// skip node if code selection has replaced it with better x86 specific op
+		if (preselection.hasBeenReplaced(node)) {
+			return;
+		}
+
+		IkeaBløck block = blocks.get((Block) node.getBlock());
+		IkeaAnd ikeaAdd = new IkeaAnd(nextRegister(node), nodes.get(node.getLeft()), nodes.get(node.getRight()), node);
 		nodes.put(node, ikeaAdd);
 		block.nodes().add(ikeaAdd);
 	}

--- a/src/main/java/com/github/firmwehr/gentle/backend/ir/nodes/IkeaAnd.java
+++ b/src/main/java/com/github/firmwehr/gentle/backend/ir/nodes/IkeaAnd.java
@@ -1,0 +1,51 @@
+package com.github.firmwehr.gentle.backend.ir.nodes;
+
+import com.github.firmwehr.gentle.backend.ir.IkeaBøx;
+import com.github.firmwehr.gentle.backend.ir.visit.IkeaVisitor;
+import firm.nodes.And;
+import firm.nodes.Node;
+
+import java.util.List;
+
+public class IkeaAnd implements IkeaNode {
+	private IkeaBøx box;
+	private final IkeaNode left;
+	private final IkeaNode right;
+	private final And and;
+
+	public IkeaAnd(IkeaBøx box, IkeaNode left, IkeaNode right, And add) {
+		this.box = box;
+		this.left = left;
+		this.right = right;
+		this.and = add;
+	}
+
+	@Override
+	public IkeaBøx box() {
+		return this.box;
+	}
+
+	@Override
+	public List<IkeaNode> parents() {
+		return List.of(this.left, this.right);
+	}
+
+	public IkeaNode getLeft() {
+		return left;
+	}
+
+	public IkeaNode getRight() {
+		return right;
+	}
+
+	@Override
+	public <T> T accept(IkeaVisitor<T> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public List<Node> getUnderlyingFirmNodes() {
+		return List.of(and);
+	}
+
+}

--- a/src/main/java/com/github/firmwehr/gentle/backend/ir/visit/DjungelskogVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/backend/ir/visit/DjungelskogVisitor.java
@@ -8,6 +8,7 @@ import com.github.firmwehr.gentle.backend.ir.IkeaImmediate;
 import com.github.firmwehr.gentle.backend.ir.IkeaVirtualRegister;
 import com.github.firmwehr.gentle.backend.ir.nodes.BoxScheme;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAdd;
+import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAnd;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaArgNode;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCall;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCmp;
@@ -99,6 +100,11 @@ public class DjungelskogVisitor implements IkeaVisitor<String> {
 	@Override
 	public String visit(IkeaAdd add) {
 		return simpleBinaryOperator("add", add.getRight().box(), add.getLeft().box(), add.box());
+	}
+
+	@Override
+	public String visit(IkeaAnd and) {
+		return simpleBinaryOperator("and", and.getRight().box(), and.getLeft().box(), and.box());
 	}
 
 	@Override

--- a/src/main/java/com/github/firmwehr/gentle/backend/ir/visit/IkeaVisitor.java
+++ b/src/main/java/com/github/firmwehr/gentle/backend/ir/visit/IkeaVisitor.java
@@ -2,6 +2,7 @@ package com.github.firmwehr.gentle.backend.ir.visit;
 
 import com.github.firmwehr.gentle.backend.ir.IkeaBløck;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAdd;
+import com.github.firmwehr.gentle.backend.ir.nodes.IkeaAnd;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaArgNode;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCall;
 import com.github.firmwehr.gentle.backend.ir.nodes.IkeaCmp;
@@ -37,6 +38,10 @@ public interface IkeaVisitor<T> {
 
 	default T visit(IkeaAdd add) {
 		return defaultVisit(add);
+	}
+
+	default T visit(IkeaAnd and) {
+		return defaultVisit(and);
 	}
 
 	default T visit(IkeaArgNode argNode) {


### PR DESCRIPTION
`(a >> n) << n` and `(a >>> n) << n` can be replaced by one `a & -(1 << n)`. If n is a constant, that means it's only one instruction instead of two.