### PR TITLE
Fix purifier

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/PureFunctionOptimization.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/PureFunctionOptimization.java
@@ -11,6 +11,7 @@ import firm.Mode;
 import firm.nodes.Address;
 import firm.nodes.Block;
 import firm.nodes.Call;
+import firm.nodes.Load;
 import firm.nodes.Node;
 import firm.nodes.NodeVisitor;
 import firm.nodes.Proj;
@@ -101,6 +102,11 @@ public class PureFunctionOptimization {
 		graph.walk(new NodeVisitor.Default() {
 			@Override
 			public void visit(Store node) {
+				result.set(true);
+			}
+
+			@Override
+			public void visit(Load node) {
 				result.set(true);
 			}
 


### PR DESCRIPTION
The old purifier assumed that loads were pure since they had no observable side effects, but with the new purifier letting gvn deduplicate and reorder pure function calls, that is no longer true since stores might have happened in-between.