### PR TITLE
Remove methods that are never called

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
@@ -76,6 +76,10 @@ public interface CommandArguments {
 	@Option(names = "--no-inlining", description = "do not inline code")
 	boolean noInlining();
 
+	@Option(names = "--no-free-unused-graphs",
+		description = "do not remove graphs that are not reachable from the main method")
+	boolean noFreeUnusedGraphs();
+
 	@Parameter(index = 0, converter = ExistingFileConverter.class, description = "file to read and operate on",
 		paramLabel = "FILE")
 	Path path();

--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmBuilder.java
@@ -116,6 +116,7 @@ public class FirmBuilder {
 			if (!CompilerArguments.get().noInlining()) {
 				builder.addCallGraphStep(MethodInliningOptimization.methodInlineOptimization());
 			}
+			builder.freeUnusedGraphs(!CompilerArguments.get().noFreeUnusedGraphs());
 		} else {
 			LOGGER.info("optimization level set to 0, all optional optimization will be disabled");
 		}

--- a/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmGraphBuilder.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/construction/FirmGraphBuilder.java
@@ -51,6 +51,7 @@ import firm.Construction;
 import firm.Entity;
 import firm.Graph;
 import firm.Mode;
+import firm.Program;
 import firm.Relation;
 import firm.Type;
 import firm.bindings.binding_ircons;
@@ -134,6 +135,8 @@ public class FirmGraphBuilder {
 				construction.setVariable(index, proj);
 				debugStore.putMetadata(proj, forElement(parameter));
 			}
+		} else {
+			Program.setMainGraph(currentGraph);
 		}
 
 		processMethodBody(new Context(construction, slotTable, method), method);

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
@@ -254,7 +254,7 @@ public class ConstantFolding extends NodeVisitor.Default {
 				continue;
 			}
 			block.setPred(i, predBlock.getPred(0));
-			LOGGER.debug("deleted %s in the middle of %s and %s", predBlock, block, predBlock.getPred(0));
+			LOGGER.debug("deletable %s in the middle of %s and %s", predBlock, block, predBlock.getPred(0));
 		}
 	}
 

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
@@ -180,10 +180,6 @@ public final class CallGraph {
 		}
 	}
 
-	public Set<Call> callSitesIn(Graph graph) {
-		return calledMethods.outEdges(graph.getEntity());
-	}
-
 	@Override
 	public String toString() {
 		return "CallGraph";

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
@@ -49,6 +49,7 @@ public final class CallGraph {
 
 	private static void buildNode(MutableNetwork<Entity, Call> network, Graph graph) {
 		Entity entity = graph.getEntity();
+		network.addNode(entity);
 		graph.walk(new NodeVisitor.Default() {
 			@Override
 			public void visit(Call node) {
@@ -81,6 +82,7 @@ public final class CallGraph {
 			if (entitiesToUpdate.contains(node)) {
 				buildNode(updated, node.getGraph());
 			} else {
+				updated.addNode(node);
 				// re-insert outgoing edges of this node, as we don't want to update it
 				for (Call call : calledMethods.outEdges(node)) {
 					updated.addEdge(node, ((Address) call.getPtr()).getEntity(), call);
@@ -140,6 +142,13 @@ public final class CallGraph {
 	}
 
 	/**
+	 * Returns the calls inside this graph
+	 */
+	public Set<Call> callSitesIn(Graph graph) {
+		return calledMethods.outEdges(graph.getEntity());
+	}
+
+	/**
 	 * Each graph is only visited after all callees were visited, except for graphs forming a cycle.
 	 * <p>
 	 * For a cycle with exact one caller, e.g. {@code c -> a -> b -> a}, {@code b} will be visited before {@code a}.
@@ -178,6 +187,10 @@ public final class CallGraph {
 	@Override
 	public String toString() {
 		return "CallGraph";
+	}
+
+	public void debug() {
+		System.out.println(calledMethods);
 	}
 
 	public enum Effect {

--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/callgraph/CallGraph.java
@@ -189,10 +189,6 @@ public final class CallGraph {
 		return "CallGraph";
 	}
 
-	public void debug() {
-		System.out.println(calledMethods);
-	}
-
 	public enum Effect {
 		LOAD, // loads from memory
 		STORE, // stores into memory


### PR DESCRIPTION
Especially with method inlining, this might help to further reduce compilation time as we really do not need to generate code for methods which are never called (anymore).