### PR TITLE
Shorten flag names and add non-negated versions

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CommandArguments.java
@@ -63,35 +63,63 @@ public interface CommandArguments {
 	@Option(names = "--optimize", description = "enable all optimizations for the current backend")
 	boolean optimize();
 
-	@Option(names = "--no-advanced-code-selection", description = "disable advanced x86 code generation")
-	boolean noAdvancedCodeSelection();
+	@Option(names = "--acs", description = "enable advanced x86 code generation")
+	boolean acs();
 
-	@Option(names = "--no-constant-folding", description = "don't do constant folding")
-	boolean noConstantFolding();
+	@Option(names = "--no-acs", description = "disable advanced x86 code generation")
+	boolean noAcs();
 
-	@Option(names = "--no-arithmetic-optimization", description = "don't do arithmetic optimizations")
-	boolean noArithmeticOptimizations();
+	// Constant folding is always active by default, so there's no point in a --cf flag
+	@Option(names = "--no-cf", description = "don't do constant folding")
+	boolean noCf();
 
-	@Option(names = "--no-boolean-optimization", description = "don't perform boolean optimizations")
-	boolean noBooleanOptimizations();
+	@Option(names = "--arith", description = "do arithmetic optimizations")
+	boolean arith();
 
-	@Option(names = "--no-remove-unused", description = "don't remove unused call arguments")
-	boolean noRemoveUnused();
+	@Option(names = "--no-arith", description = "don't do arithmetic optimizations")
+	boolean noArith();
+
+	@Option(names = "--bool", description = "perform boolean optimizations")
+	boolean bool();
+
+	@Option(names = "--no-bool", description = "don't perform boolean optimizations")
+	boolean noBool();
+
+	@Option(names = "--escape", description = "remove allocations for objects that do not escape")
+	boolean escape();
+
+	@Option(names = "--no-escape", description = "keep allocations for objects that do not escape")
+	boolean noEscape();
+
+	@Option(names = "--gvn", description = "enable global value numbering")
+	boolean gvn();
 
 	@Option(names = "--no-gvn", description = "disable global value numbering")
-	boolean noGlobalValueNumbering();
+	boolean noGvn();
 
-	@Option(names = "--no-escape-analysis", description = "keep allocations for objects that do not escape")
-	boolean noEscapeAnalysis();
+	@Option(names = "--inline", description = "inline code")
+	boolean inline();
 
-	@Option(names = "--no-remove-pure-functions", description = "don't remove pure function calls")
-	boolean noRemovePureFunctions();
+	@Option(names = "--no-inline", description = "don't inline code")
+	boolean noInline();
 
-	@Option(names = "--no-inlining", description = "don't inline code")
-	boolean noInlining();
+	@Option(names = "--rm-unused", description = "remove unused call arguments")
+	boolean rmUnused();
 
-	@Option(names = "--no-free-unused-graphs", description = "don't remove unreachable graphs")
-	boolean noFreeUnusedGraphs();
+	@Option(names = "--no-rm-unused", description = "don't remove unused call arguments")
+	boolean noRmUnused();
+
+	@Option(names = "--rm-pure", description = "remove pure function calls")
+	boolean rmPure();
+
+	@Option(names = "--no-rm-pure", description = "don't remove pure function calls")
+	boolean noRmPure();
+
+	@Option(names = "--rm-graphs", description = "remove unreachable graphs")
+	boolean rmGraphs();
+
+	@Option(names = "--no-rm-graphs", description = "don't remove unreachable graphs")
+	boolean noRmGraphs();
 
 	@Parameter(index = 0, converter = ExistingFileConverter.class, description = "file to read and operate on",
 		paramLabel = "FILE")

--- a/src/main/java/com/github/firmwehr/gentle/cli/CompilerArguments.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/CompilerArguments.java
@@ -12,22 +12,25 @@ public class CompilerArguments {
 	}
 
 	public static Optimizations optimizations() {
-		boolean o1 = get().optimizerLevel().orElse(0) >= 1;
-		boolean lego = /* o1 || */ get().lego();
-		boolean optimize = o1 || get().optimize();
+		CommandArguments args = get();
 
-		boolean constantFolding = !get().noConstantFolding();
-		boolean advancedCodeSelection = optimize && !get().noAdvancedCodeSelection();
-		boolean arithmeticOpt = optimize && !get().noArithmeticOptimizations();
-		boolean booleanOpt = optimize && !get().noBooleanOptimizations();
-		boolean escapeAnalysis = optimize && !get().noEscapeAnalysis();
-		boolean globalValueNumbering = optimize && !get().noGlobalValueNumbering();
-		boolean inlining = optimize && !get().noInlining();
-		boolean removePureFunctions = optimize && !get().noRemovePureFunctions();
-		boolean removeUnused = optimize && !get().noRemoveUnused();
-		boolean removeUnusedGraphs = optimize && !get().noFreeUnusedGraphs();
+		boolean o1 = args.optimizerLevel().orElse(0) >= 1;
+		boolean lego = /* o1 || */ args.lego();
+		boolean optimize = o1 || args.optimize();
+
+		boolean constantFolding = !args.noCf();
+		boolean advancedCodeSelection = (optimize || args.acs()) && !args.noAcs();
+		boolean arithmeticOpt = (optimize || args.arith()) && !args.noArith();
+		boolean booleanOpt = (optimize || args.bool()) && !args.noBool();
+		boolean escapeAnalysis = (optimize || args.escape()) && !args.noEscape();
+		boolean globalValueNumbering = (optimize || args.gvn()) && !args.noGvn();
+		boolean inlining = (optimize || args.inline()) && !args.noInline();
+		boolean removeUnused = (optimize || args.rmUnused()) && !args.noRmUnused();
+		boolean removePureFunctions = (optimize || args.rmPure()) && !args.noRmPure();
+		boolean removeUnusedGraphs = (optimize || args.rmGraphs()) && !args.noRmGraphs();
 
 		return new Optimizations(lego, constantFolding, advancedCodeSelection, arithmeticOpt, booleanOpt,
-			escapeAnalysis, globalValueNumbering, inlining, removePureFunctions, removeUnused, removeUnusedGraphs);
+			escapeAnalysis, globalValueNumbering, inlining, removeUnused, removePureFunctions,
+			removeUnusedGraphs);
 	}
 }

--- a/src/main/java/com/github/firmwehr/gentle/cli/Optimizations.java
+++ b/src/main/java/com/github/firmwehr/gentle/cli/Optimizations.java
@@ -9,8 +9,8 @@ public record Optimizations(
 	boolean escapeAnalysis,
 	boolean globalValueNumbering,
 	boolean inlining,
-	boolean removePureFunctions,
 	boolean removeUnused,
+	boolean removePureFunctions,
 	boolean removeUnusedGraphs
 ) {
 }


### PR DESCRIPTION
This lets you enable individual optimizations, e. g. `./run Foo.java --gvn` instead of `./run Foo.java --optimize --no-xxx --no-yyy --no-zzz ....`