### PR TITLE
Fix CF for Eor nodes

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/ConstantFolding.java
@@ -393,6 +393,11 @@ public class ConstantFolding extends NodeVisitor.Default {
 	}
 
 	@Override
+	public void visit(Eor node) {
+		updateTarVal(node, TargetValue::eor);
+	}
+
+	@Override
 	public void visit(Id node) {
 		updateTarVal(node, tarValOf(node.getPred()));
 	}


### PR DESCRIPTION
We use Eor for boolean negation but forgot to include it in the constant folding optimization.