### PR TITLE
Fix unconditional jump in incorrect places

### DIFF
--- a/src/main/java/com/github/firmwehr/gentle/firm/optimization/BooleanOptimization.java
+++ b/src/main/java/com/github/firmwehr/gentle/firm/optimization/BooleanOptimization.java
@@ -99,13 +99,15 @@ public class BooleanOptimization extends NodeVisitor.Default {
 				falseNode = tmp;
 			}
 
-			Node mux = match.cmp().getGraph().newMux(match.cmp().getBlock(), match.cmp(), falseNode, trueNode);
+			Node mux = match.cond().getGraph().newMux(match.cond().getBlock(), match.cmp(), falseNode, trueNode);
 
 			for (BackEdges.Edge out : BackEdges.getOuts(phi)) {
 				out.node.setPred(out.pos, mux);
 			}
 
-			Node jmp = match.cmp().getGraph().newJmp(match.cmp().getBlock());
+			// The unconditional jump must be placed in the same block as the cond it replaces, or our graph may get
+			// messed up.
+			Node jmp = match.cond().getGraph().newJmp(match.cond().getBlock());
 			binding_irnode.set_irn_in(match.afterBlock().ptr, 1, Node.getBufferFromNodeList(new Node[]{jmp}));
 
 			changed = true;


### PR DESCRIPTION
Boolean optimization would place an unconditional jump in the incorrect location, turning this
![image](https://user-images.githubusercontent.com/11077553/152576146-21e074d2-4e91-4652-923e-e0e37ac03d36.png)
into this
![image](https://user-images.githubusercontent.com/11077553/152576230-7fcaaeeb-5706-4274-8408-f118ebb92bf5.png)
but now after the fix, it does this
![image](https://user-images.githubusercontent.com/11077553/152576337-0d35f1b2-9fc3-496d-bdb1-f255e5502403.png)
